### PR TITLE
fix shift size in TTEntry::save

### DIFF
--- a/source/tt.h
+++ b/source/tt.h
@@ -31,7 +31,7 @@ struct TTEntry {
     if ((k >> 48) != key16)
       move16 = (uint16_t)m;
 
-    if ((k >> 16) != key16)
+    if ((k >> 48) != key16)
     {
       key16   = (int16_t)(k >> 48);
       value16 = (int16_t)v;


### PR DESCRIPTION
多分シフトサイズが違うと思うので直してみましたがあってるでしょうか？
将来的にdepthなどの判定を入れるかもしれないので、if分そのものは残してあります。
