### PR TITLE
Intel Xeon Phi Processor 7250においてCPUを100%使い切れるようにした

### DIFF
--- a/source/usi.cpp
+++ b/source/usi.cpp
@@ -226,7 +226,7 @@ namespace USI
 		// 並列探索するときのスレッド数
 		// CPUの搭載コア数をデフォルトとすべきかも知れないが余計なお世話のような気もするのでしていない。
 
-		o["Threads"] << Option(4, 1, 128, [](auto& o) { Threads.read_usi_options(); });
+		o["Threads"] << Option(4, 1, 512, [](auto& o) { Threads.read_usi_options(); });
 
 		// USIプロトコルでは、"USI_Hash"なのだが、
 		// 置換表サイズを変更しての自己対戦などをさせたいので、


### PR DESCRIPTION
stockfish由来のプロセッサーグループの設定ロジックを変更し、Intel Xeon Phi Processor 7250においてCPUを100%使い切れるよう変更しました。stockfish由来のロジックでは、全てのプロセッサーグルプに同数の論理プロセッサーが含まれることを仮定していますが、Intel Xeon Phi Processor 7250でWindows Server 2016を動かした場合、プロセッサーグルプ内の論理プロセッサーの数が64・64・64・64・16と不均一で、CPUを100%使い切ることが出来ませんでした。この問題を解決するため、先頭のプロセッサーグループから順に貪欲にスレッドIDを割り当てるよう変更しました。

よろしくお願いいたします。
