### PR TITLE
詰将棋エンジン用のテストコマンドを追加した

### DIFF
--- a/source/extra/config.h
+++ b/source/extra/config.h
@@ -393,6 +393,7 @@
 #define EVAL_NO_USE
 #define LONG_EFFECT_LIBRARY
 #define USE_KEY_AFTER
+#define ENABLE_TEST_CMD
 #endif
 
 // --- ユーザーの自作エンジンとして実行ファイルを公開するとき用の設定集

--- a/source/usi.cpp
+++ b/source/usi.cpp
@@ -26,6 +26,9 @@ extern void test_cmd(Position& pos, istringstream& is);
 extern void perft(Position& pos, istringstream& is);
 extern void generate_moves_cmd(Position& pos);
 extern void bench_cmd(Position& pos, istringstream& is);
+#ifdef MATE_ENGINE
+extern void test_mate_engine_cmd(Position& pos, istringstream& is);
+#endif
 #endif
 
 // 定跡を作るコマンド
@@ -713,6 +716,10 @@ void USI::loop(int argc, char* argv[])
 
 		// ベンチコマンド
 		else if (token == "bench") bench_cmd(pos, is);
+
+#ifdef MATE_ENGINE
+		else if (token == "test_mate_engine") test_mate_engine_cmd(pos, is);
+#endif
 #endif
 
 #ifdef ENABLE_MAKEBOOK_CMD


### PR DESCRIPTION
test_mate_engineコマンドを追加しました。

その他以下の細かい修正を加えてあります。

- 1手詰みルーチンで詰みを判定できない場合に不詰みと判定してしまうバグを修正した
- 探索ノード数のカウントにPositionの機能を使用するようにした
- パラメーター調整により一部の問題が解けるようになった

よろしくお願いいたします。
