### PR TITLE
AperyBook: 乱数初期化はinit()内で

### DIFF
--- a/source/extra/book/apery_book.cpp
+++ b/source/extra/book/apery_book.cpp
@@ -25,12 +25,15 @@
 
 namespace Book {
 
-MT64bit AperyBook::mt64bit_; // 定跡のhash生成用なので、seedは固定でデフォルト値を使う。
 Key AperyBook::ZobPiece[PIECE_NB - 1][SQ_NB];
 Key AperyBook::ZobHand[PIECE_HAND_NB - 1][19]; // 持ち駒の同一種類の駒の数ごと
 Key AperyBook::ZobTurn;
 
 void AperyBook::init() {
+	// 定跡のhash生成用なので、seedは固定でデフォルト値を使う。
+	// 未初期化乱数でhashが毎回変更されるのを防ぐため、init()が呼ばれる度に乱数は初期化する。
+	// （そもそもinit()を呼ぶのは1回きりでも良いのだけど、今の実装ではコンストラクタから毎回呼ばれるので。）
+	MT64bit mt64bit_;
     for (Piece p = PIECE_ZERO; p < PIECE_NB - 1; ++p) {
         for (Square sq = SQ_ZERO; sq < SQ_NB; ++sq)
             ZobPiece[p][sq] = mt64bit_.random() * (p != NO_PIECE);

--- a/source/extra/book/apery_book.h
+++ b/source/extra/book/apery_book.h
@@ -49,7 +49,6 @@ public:
 private:
     static void init();
 
-    static MT64bit mt64bit_; // 定跡のhash生成用なので、seedは固定でデフォルト値を使う。
     std::vector<AperyBookEntry> empty_entries_;
     std::unordered_map<Key, std::vector<AperyBookEntry>> book_;
 


### PR DESCRIPTION
AperyBookのコンストラクタを複数回呼び出すと乱数未初期化のままhashを再生成しているので、
AperyBookを複数、もしくは複数回取り扱う際に支障になりそうです。