### PR TITLE
Makefile: stacksize 100000000 (only windows build)

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -38,11 +38,15 @@ CFLAGS  += -Wl,-s
 # これを指定していると、各CPU向けの実行ファイルが生成されないので指定すべきではない。
 # CFLAGS   += -march=native
 
+# デバッグ情報を付加
+# CFLAGS  += -g3 -ggdb
+
 LDFLAGS  = -lpthread #-lboost_mpi -lboost_serialization
 LIBS     =
 INCLUDE  = #-I../include
 
 ifeq ($(OS),Windows_NT)
+  CFLAGS += -Wl,--stack,100000000
   LDFLAGS += -static
   TARGET = YaneuraOu-by-gcc.exe
 else


### PR DESCRIPTION
msys2 上でのビルド設定にはスタック領域サイズの指定が無かったようなので、Makefileに追加してみました。linuxのbash上では `$ ulimit -s 16384` とか `$ ulimit -s unlimited` とかやるのが流儀なのかもしれないので（よくは知らない）、Windows環境にのみ指定しています。

ちなみに 100000000 の数字は、VisualC++のビルド設定から取りました。

- [V4.41時点での StackReserveSize](https://github.com/yaneurao/YaneuraOu/blob/02c9c583c9424fb6abf0e7c0772bfb013eef936e/source/YaneuraOu.vcxproj#L199)
- [現在の StackReserveSize](https://github.com/yaneurao/YaneuraOu/blob/0a0ca01936dfcebac8582efa831b77bf6d953c85/source/props/YaneuraOuSolution-release-x64.props#L42)

何でMakefileがShift-JISなのかなとは思いましたが、UTF-8にすると、UTF-8 without BOM (UTF-8N)ではなくUTF-8 with BOMに化ける危険があるからなのでしょうか。