### PR TITLE
extra/config.hのインクルードに<functional>を追加

### DIFF
--- a/source/extra/config.h
+++ b/source/extra/config.h
@@ -482,6 +482,7 @@ extern GlobalOptions_ GlobalOptions;
 #include <climits>  // INT_MAX
 #include <cstddef>  // offsetof
 #include <array>
+#include <functional>
 
 
 // --------------------


### PR DESCRIPTION
Homebrewのg++-7.1.0でstd::functionが未定義と言われたので、書いておいたほうが良さそうに思います。