### PR TITLE
makebook from_sfenで先手のみ/後手のみの手を採択する機能を追加

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -14,8 +14,8 @@ YANEURAOU_EDITION = YANEURAOU_2017_EARLY_ENGINE
 #YANEURAOU_EDITION = MUST_CAPTURE_SHOGI_ENGINE
 
 # clangでコンパイルしたほうがgccより数%速いっぽい。
-# COMPILER = g++
-COMPILER = clang++
+COMPILER = g++
+# COMPILER = clang++
 
 # 標準的なコンパイルオプション
 CFLAGS   = -std=c++14 -fno-exceptions -fno-rtti -Wextra -Ofast -MMD -MP -fpermissive

--- a/source/extra/book/book.cpp
+++ b/source/extra/book/book.cpp
@@ -128,16 +128,21 @@ namespace Book
 
 		if (from_sfen || from_thinking)
 		{
-			// sfenファイル名
-			is >> token;
-			string sfen_name = token;
-
+			string sfen_name;
 			// qh : from_sfenにしたときに先手だけ切り取る、後手だけ切り取るといった処理をしたい
 			string sfen_name_gote;
-			if(from_sfen){
+			// sfenファイル名
+			is >> token;
+
+			if(token == "bw"){
+			  is >> token;
+			  sfen_name = token;
 			  is >> token;
 			  sfen_name_gote = token;
+			}else{
+			  sfen_name = token;
 			}
+			
 			// 定跡ファイル名
 			string book_name;
 			is >> book_name;
@@ -279,13 +284,13 @@ namespace Book
 				{
 				  if (i < start_moves - 1)
 				    continue;
+				  // qh : 先手だけ使う棋譜、後手だけ使う棋譜に対応
+				  if( (isSente && i%2 ==1) || (!isSente && i%2 == 0)){
+				    continue;
+				  }
 				  
 				  if (from_sfen)
 				    {
-				      // qh : 先手だけ使う棋譜、後手だけ使う棋譜に対応
-				      if( (isSente && i%2 ==1) || (!isSente && i%2 == 0)){
-					continue;
-				      }
 				      // この場合、m[i + 1]が必要になるので、m.size()-1までしかループできない。
 				      BookPos bp(m[i], m[i + 1], VALUE_ZERO, 32, 1);
 				      insert_book_pos(book, sf[i], bp);

--- a/source/extra/book/book.cpp
+++ b/source/extra/book/book.cpp
@@ -285,7 +285,7 @@ namespace Book
 				  if (i < start_moves - 1)
 				    continue;
 				  // qh : 先手だけ使う棋譜、後手だけ使う棋譜に対応
-				  if( (isSente && i%2 ==1) || (!isSente && i%2 == 0)){
+				  if( sfen_name_gote != "" && (isSente && i%2 ==1 || !isSente && i%2 == 0)){
 				    continue;
 				  }
 				  


### PR DESCRIPTION
相手が手を誤った時にそれを的確に咎めるという、定跡スナイパー理論に基づいた定跡作りではほぼ必須と言える、先手/後手のみの手を定跡に採択する機能を追加しました。具体的には以下の様な設定で動かすようにしました・

makebook from_sfen 先手のsfen 後手のsfen データベース名 moves 手数

入力例：
makebook from_sfen sente.sfen gote.sfen test.db moves 100

注意：
from_sfen以外の動作チェックはしてないです。大定跡形式で変な動作をしないとは断言できません...