### PR TITLE
add "test kifconvert" , fix white turn convert to kif

### DIFF
--- a/source/extra/all.h
+++ b/source/extra/all.h
@@ -18,6 +18,7 @@
 #include "long_effect.h"
 #include "book/book.h"
 #include "../learn/learn.h"
+#include "kif_converter/kif_convert_tools.h"
 
 // これもおまけしておく。
 using namespace std;

--- a/source/extra/kif_converter/kif_convert_tools.cpp
+++ b/source/extra/kif_converter/kif_convert_tools.cpp
@@ -296,8 +296,8 @@ namespace KifConvertTools
 				Piece pr = raw_type_of(pt);
 
 				// 金・銀・成金は直の表記が有り得る
-				bool is_like_goldsilver = (pr == SILVER || pr == GOLD || pr == PRO_PAWN || pr == PRO_LANCE
-					|| pr == PRO_KNIGHT || pr == PRO_SILVER);
+				bool is_like_goldsilver = (pt == SILVER || pt == GOLD || pt == PRO_PAWN || pt == PRO_LANCE
+					|| pt == PRO_KNIGHT || pt == PRO_SILVER);
 
 				// 移動元・移動先の座標
 				Square from = move_from(m), to = move_to(m);

--- a/source/extra/kif_converter/kif_convert_tools.cpp
+++ b/source/extra/kif_converter/kif_convert_tools.cpp
@@ -512,22 +512,22 @@ namespace KifConvertTools
 	std::string to_kif_string(Position& pos, Move m , SquareFormat fmt)
 	{
 		KifStringBuilder<std::string, KifConstLocale> builder;
-		return builder.to_kif_string(m, pos.moved_piece_before(m), pos.state()->lastMove , pos.side_to_move() , fmt);
+		return builder.to_kif_string(m, type_of(pos.moved_piece_before(m)), pos.state()->lastMove , pos.side_to_move() , fmt);
 	}
 	std::string to_kif_u8string(Position& pos, Move m , SquareFormat fmt)
 	{
 		KifStringBuilder<std::string, KifConstUtf8> builder;
-		return builder.to_kif_string(m, pos.moved_piece_before(m), pos.state()->lastMove , pos.side_to_move() , fmt);
+		return builder.to_kif_string(m, type_of(pos.moved_piece_before(m)), pos.state()->lastMove , pos.side_to_move() , fmt);
 	}
 	std::u16string to_kif_u16string(Position& pos, Move m , SquareFormat fmt)
 	{
 		KifStringBuilder<std::u16string, KifConstUtf16> builder;
-		return builder.to_kif_string(m, pos.moved_piece_before(m), pos.state()->lastMove , pos.side_to_move() , fmt);
+		return builder.to_kif_string(m, type_of(pos.moved_piece_before(m)), pos.state()->lastMove , pos.side_to_move() , fmt);
 	}
 	std::u32string to_kif_u32string(Position& pos, Move m , SquareFormat fmt)
 	{
 		KifStringBuilder<std::u32string, KifConstUtf32> builder;
-		return builder.to_kif_string(m, pos.moved_piece_before(m), pos.state()->lastMove , pos.side_to_move() , fmt);
+		return builder.to_kif_string(m, type_of(pos.moved_piece_before(m)), pos.state()->lastMove , pos.side_to_move() , fmt);
 	}
 
 	// KIF2形式の指し手表現文字列を取得する。

--- a/source/extra/test_cmd.cpp
+++ b/source/extra/test_cmd.cpp
@@ -1555,6 +1555,75 @@ void dump_sfen(Position& pos, istringstream& is)
 }
 #endif
 
+#ifdef USE_KIF_CONVERT_TOOLS
+void test_kif_convert_tools(Position& pos, istringstream& is)
+{
+	is_ready();
+
+	std::string token = "";
+	is >> token;
+
+	bool sfen = false, csa = false, csa1 = false, kif = false, kif2 = false, all = (token == "");
+
+	while(true)
+	{
+		token = "";
+		is >> token;
+		if (token == "")
+			break;
+		if (token == "sfen")
+			sfen = true;
+		if (token == "csa")
+			csa = true;
+		else if (token == "csa1")
+			csa1 = true;
+		else if (token == "kif")
+			kif = true;
+		else if (token == "kif2")
+			kif2 = true;
+	}
+
+	std::cout << "position: " << pos.sfen() << std::endl;
+
+	if (all || sfen)
+	{
+		std::cout << "sfen:";
+		for (auto m : MoveList<LEGAL_ALL>(pos))
+			std::cout << " " << m.move;
+		std::cout << std::endl;
+	}
+	if (all || csa)
+	{
+		std::cout << "csa:";
+		for (auto m : MoveList<LEGAL_ALL>(pos))
+			std::cout << " " << KifConvertTools::to_csa_string(pos, m.move);
+		std::cout << std::endl;
+	}
+	if (all || csa1)
+	{
+		std::cout << "csa1:";
+		for (auto m : MoveList<LEGAL_ALL>(pos))
+			std::cout << " " << KifConvertTools::to_csa1_string(pos, m.move);
+		std::cout << std::endl;
+	}
+	if (all || kif)
+	{
+		std::cout << "kif:";
+		for (auto m : MoveList<LEGAL_ALL>(pos))
+			std::cout << " " << KifConvertTools::to_kif_string(pos, m.move);
+		std::cout << std::endl;
+	}
+	if (all || kif2)
+	{
+		std::cout << "kif2:";
+		for (auto m : MoveList<LEGAL_ALL>(pos))
+			std::cout << " " << KifConvertTools::to_kif2_string(pos, m.move);
+		std::cout << std::endl;
+	}
+
+}
+#endif // #ifdef USE_KIF_CONVERT_TOOLS
+
 void test_cmd(Position& pos, istringstream& is)
 {
 	// 探索をするかも知れないので初期化しておく。
@@ -1580,6 +1649,9 @@ void test_cmd(Position& pos, istringstream& is)
 #ifdef EVAL_KPPT
 	else if (param == "evalmerge") eval_merge(is);                   // 評価関数の合成コマンド
 	else if (param == "evalconvert") eval_convert(is);               // 評価関数の変換コマンド
+#endif
+#ifdef USE_KIF_CONVERT_TOOLS
+	else if (param == "kifconvert") test_kif_convert_tools(pos, is); // 現局面からの全合法手を各種形式で出力チェック
 #endif
 	else {
 		cout << "test unit               // UnitTest" << endl;


### PR DESCRIPTION
testコマンドの方にテスト絡みを実装してみました。
後手番でのKIF形式出力で、Pieceから手番情報を除き損ねていて、配列境界をはみ出していたので修正しました。

修正前:

```
$ ./msys2/2017Early/YaneuraOu-2017-early-clang-sse42 isready , position startpos moves 5i5h , test kifconvert , quit
info string created shared eval memory.
info string Eval Check Sum = 65cd7c55a9d4cd9 , Eval File = elmo(WCSC27)
readyok
position: lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B2K2R1/LNSG1GSNL w - 2
sfen: 1c1d 2c2d 3c3d 4c4d 5c5d 6c6d 7c7d 8c8d 9c9d 1a1b 9a9b 3a3b 3a4b 7a6b 7a7b 8b3b 8b4b 8b5b 8b6b 8b7b 8b9b 4a3b 4a4b 4a5b 5a4b 5a5b 5a6b 6a5b 6a6b 6a7b
csa: -1314FU -2324FU -3334FU -4344FU -5354FU -6364FU -7374FU -8384FU -9394FU -1112KY -9192KY -3132GI -3142GI -7162GI -7172GI -8232HI -8242HI -8252HI -8262HI -8272HI -8292HI -4132KI -4142KI -4152KI -5142OU -5152OU -5162OU -6152KI -6162KI -6172KI
csa1: 1314FU 2324FU 3334FU 4344FU 5354FU 6364FU 7374FU 8384FU 9394FU 1112KY 9192KY 3132GI 3142GI 7162GI 7172GI 8232HI 8242HI 8252HI 8262HI 8272HI 8292HI 4132KI 4142KI 4152KI 5142OU 5152OU 5162OU 6152KI 6162KI 6172KI
kif: △14 △24 △34 △44 △54 △64 △74 △84 △94 △12▒▒U(11) △92▒▒U(91) △32△32(31) △42△42(31) △62△62(71) △72△72(71) △32▒▒32(82) △42▒▒42(82) △52▒▒52(82) △62▒▒62(82) △72▒▒72(82) △92▒▒92(82) △32△32(41) △42△42(41) △52△52(41) △42(51) △52(51) △62(51) △52△52(61) △62△62(61) △72△72(61)
kif2: △14歩 △24歩 △34歩 △44歩 △54歩 △64歩 △74歩 △84歩 △94歩 △12香 △92香 △32銀 △42銀 △62銀 △72銀 △32飛 △42飛 △52飛 △62飛 △72飛 △92飛 △32金 △42金 △52金左 △42玉 △52玉 △62玉 △52金右 △62金 △72金
```

修正後:

```
$ ./msys2/2017Early/YaneuraOu-2017-early-clang-sse42 isready , position startpos moves 5i5h , test kifconvert , quit
info string created shared eval memory.
info string Eval Check Sum = 65cd7c55a9d4cd9 , Eval File = elmo(WCSC27)
readyok
position: lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B2K2R1/LNSG1GSNL w - 2
sfen: 1c1d 2c2d 3c3d 4c4d 5c5d 6c6d 7c7d 8c8d 9c9d 1a1b 9a9b 3a3b 3a4b 7a6b 7a7b 8b3b 8b4b 8b5b 8b6b 8b7b 8b9b 4a3b 4a4b 4a5b 5a4b 5a5b 5a6b 6a5b 6a6b 6a7b
csa: -1314FU -2324FU -3334FU -4344FU -5354FU -6364FU -7374FU -8384FU -9394FU -1112KY -9192KY -3132GI -3142GI -7162GI -7172GI -8232HI -8242HI -8252HI -8262HI -8272HI -8292HI -4132KI -4142KI -4152KI -5142OU -5152OU -5162OU -6152KI -6162KI -6172KI
csa1: 1314FU 2324FU 3334FU 4344FU 5354FU 6364FU 7374FU 8384FU 9394FU 1112KY 9192KY 3132GI 3142GI 7162GI 7172GI 8232HI 8242HI 8252HI 8262HI 8272HI 8292HI 4132KI 4142KI 4152KI 5142OU 5152OU 5162OU 6152KI 6162KI 6172KI
kif: △14歩(13) △24歩(23) △34歩(33) △44歩(43) △54歩(53) △64歩(63) △74歩(73) △84歩(83) △94歩(93) △12香(11) △92香(91) △32銀(31) △42銀(31) △62銀(71) △72銀(71) △32飛(82) △42飛(82) △52飛(82) △62飛(82) △72飛(82) △92飛(82) △32金(41) △42金(41) △52金(41) △42玉(51) △52玉(51) △62玉(51) △52金(61) △62金(61) △72金(61)
kif2: △14歩 △24歩 △34歩 △44歩 △54歩 △64歩 △74歩 △84歩 △94歩 △12香 △92香 △32銀 △42銀 △62銀 △72銀 △32飛 △42飛 △52飛 △62飛 △72飛 △92飛 △32金 △42金 △52金左 △42玉 △52玉 △62玉 △52金右 △62金 △72金
```