### PR TITLE
accept gui null move

### DIFF
--- a/source/usi.cpp
+++ b/source/usi.cpp
@@ -558,7 +558,10 @@ void position_cmd(Position& pos, istringstream& is)
 		// 1手進めるごとにStateInfoが積まれていく。これは千日手の検出のために必要。
 		// ToDoあとで考える。
 		SetupStates->push(StateInfo());
-		pos.do_move(m, SetupStates->top());
+		if (m == MOVE_NULL) // do_move に MOVE_NULL を与えると死ぬので
+			pos.do_null_move(SetupStates->top());
+		else
+			pos.do_move(m, SetupStates->top());
 	}
 }
 
@@ -962,6 +965,10 @@ Move move_from_usi(const Position& pos, const std::string& str)
 
 	if (str == "win")
 		return MOVE_WIN;
+
+	// パス(null move)入力への対応 {UCI: "0000", GPSfish: "pass"}
+	if (str == "0000" || str == "null" || str == "pass")
+		return MOVE_NULL;
 
 	// usi文字列をmoveに変換するやつがいるがな..
 	Move move = move_from_usi(str);


### PR DESCRIPTION
GUIの「パス」入力（例: ShogiGUI）を受け入れる。

手番のみを変更した局面の検討を行いたい時、初期局面からの指し手の情報に null move を挟む事が考えられます。（ShogiGUIで「棋譜解析、検討モードで指し手をすべて送る」オプションを有効にし、パス `Ctrl+Alt+0` 入力する場合など）

例えば、以下のようなGUIからの局面・棋譜情報の入力が考えられます。
```
positon startpos 2g2f pass 5i6h
```

ShogiGUIの開発情報としては、以下のような仕様が挙げられています。
https://sites.google.com/site/shogixyz/home/shogigui/shogigui-kai-fa-qing-bao#TOC--
```
・投了はresignと記述する。
・勝ち宣言はwinと記述する。
・パス(null move)は0000（UCI方式)かpass(gpsfish方式）と記述する。
```

gpsfish の OpenShogiLib (OSL) 部分のソース (GPSfishでは `pass`)
http://gps.tanaka.ecc.u-tokyo.ac.jp/cgi-bin/viewvc.cgi/trunk/osl/core/osl/usi.cc?view=markup#230
```
  if (str == "pass")
    return Move::PASS(s.turn());
```

そのため、`0000`, `null`, `pass`  あたりの入力は null move として解釈した方が良いかと思います。

ただし、元となる Stockfish においては `position (startpos | <fen>) moves <fen>*` における null move の入力には対応せず、合法手のみ受け入れる設計になっているようです。

- `position` : https://github.com/official-stockfish/Stockfish/blob/master/src/uci.cpp#L56
- `UCI::move` : https://github.com/official-stockfish/Stockfish/blob/master/src/uci.cpp#L265
  Move → string 変換では、MOVE_NONE と MOVE_NULL を区別するが
```
  if (m == MOVE_NONE)
      return "(none)";

  if (m == MOVE_NULL)
      return "0000";
```
- `UCI::to_move` : https://github.com/official-stockfish/Stockfish/blob/master/src/uci.cpp#L291
文字列 → Move 変換では、不正着手としてまとめて MOVE_NONE に変換されている
