### PR TITLE
book.h: fix BookMoveSelector

### DIFF
--- a/source/extra/book/book.h
+++ b/source/extra/book/book.h
@@ -119,7 +119,7 @@ namespace Book
 
 	private:
 		// probe()の下請け
-		bool BookMoveSelector::probe_impl(Position& rootPos, PRNG& prng, bool silent, Move& bestMove, Move& ponderMove);
+		bool probe_impl(Position& rootPos, PRNG& prng, bool silent, Move& bestMove, Move& ponderMove);
 
 	};
 


### PR DESCRIPTION
clangにてbuildに失敗しましたので報告します。
```
In file included from extra/book/book.cpp:2:
extra/book/book.h:122:26: error: extra qualification on member 'probe_impl'
                bool BookMoveSelector::probe_impl(Position& rootPos, PRNG& prng, bool silent, Move& bestMove, Move& ponderMove);
                     ~~~~~~~~~~~~~~~~~~^
```
