### PR TITLE
kifconvert fix

### DIFF
--- a/source/extra/kif_converter/kif_convert_consts.h
+++ b/source/extra/kif_converter/kif_convert_consts.h
@@ -148,7 +148,7 @@ namespace KifConvertTools
 		const value_type kiflist_pad = SC(I,T," ");
 		const value_type kiflist_spendnotime = SC(I,T,"( 0:00/00:00:00)");
 		const value_type char0to9_ascii[10] = {
-			SC(I,T,"0"),SC(I,T,"１"), SC(I,T,"２"), SC(I,T,"３"), SC(I,T,"４"), SC(I,T,"５"), SC(I,T,"６"), SC(I,T,"７"), SC(I,T,"８"), SC(I,T,"９"),
+			SC(I,T,"0"),SC(I,T,"1"), SC(I,T,"2"), SC(I,T,"3"), SC(I,T,"4"), SC(I,T,"5"), SC(I,T,"6"), SC(I,T,"7"), SC(I,T,"8"), SC(I,T,"9"),
 		};
 	};
 

--- a/source/extra/kif_converter/kif_convert_tools.cpp
+++ b/source/extra/kif_converter/kif_convert_tools.cpp
@@ -386,7 +386,7 @@ namespace KifConvertTools
 					ss << constStr.kif_move_samepos;
 					// SamePosFmt_KIFsp の場合、「同」の後ろに全角空白を入れる
 					// SamePosFmt_KI2sp の場合、成り指し手、成香・成桂・成銀の指し手では全角空白を入れない
-					if (fmt.samepos_type == SamePosFmt_KIFsp || (fmt.samepos_type == SamePosFmt_KI2sp && !(is_promote(m)) && movedPieceType != PRO_LANCE && movedPieceType != PRO_KNIGHT && movedPieceType != PRO_KNIGHT))
+					if (fmt.samepos_type == SamePosFmt_KIFsp || (fmt.samepos_type == SamePosFmt_KI2sp && !(is_promote(m)) && type_of(movedPieceType) != PRO_LANCE && type_of(movedPieceType) != PRO_KNIGHT && type_of(movedPieceType) != PRO_KNIGHT))
 						ss << constStr.kif_fwsp;
 				}
 				else


### PR DESCRIPTION
- KIF形式の指し手出力でKI2型のSamePosFmtを指定し、後手番で「同成香」「同成桂」「同成銀」を指した場合、「同」の後に意図せず全角空白が入ってしまう？
- 未使用文字定数の全角/半角入力ミス

細かい修正ですが、一応念のため。