### PR TITLE
kifconvert wip20170719b

### DIFF
--- a/source/extra/kif_converter/kif_convert_consts.h
+++ b/source/extra/kif_converter/kif_convert_consts.h
@@ -21,7 +21,7 @@ namespace KifConvertTools
 	template <typename charT> struct KifConstEntry
 	{
 		KifConstEntry(const charT * _str, size_t _ealen) : str(_str), ealen(_ealen) {}
-		const std::basic_string<charT> str;
+		const charT * str;
 		const size_t ealen;
 	};
 
@@ -44,7 +44,7 @@ namespace KifConvertTools
 #if defined(__clang__) || defined(_LINUX)
 #define SCU(I, T, S, R) (KifConstEntry<T>(std::get<I>(std::make_tuple(S, u8"" S, u"" S, U"" S, L"" S)), eawidth(U"" S)))
 #else
-#define SCU(I, T, S, R) (KifConstEntry<T>(std::get<I>(std::make_tuple(R, u8"" S, u"" S, U"" S, L"" S)), eawidth(std::get<I>(std::make_tuple(U"" R, U"" S, U"" S, U"" S, U"" S)))))
+#define SCU(I, T, S, R) (KifConstEntry<T>(std::get<I>(std::make_tuple(R, u8"" S, u"" S, U"" S, L"" S)), std::get<I>(std::make_tuple(eawidth(U"" R), eawidth(U"" S), eawidth(U"" S), eawidth(U"" S), eawidth(U"" S)))))
 #endif
 
 	// 文字定数群

--- a/source/extra/kif_converter/kif_convert_tools.cpp
+++ b/source/extra/kif_converter/kif_convert_tools.cpp
@@ -6,10 +6,9 @@
 #include <string>
 #include <sstream>
 
+#include "kif_convert_consts.h"
 #include "../../position.h"
 extern void is_ready();
-
-#include "kif_convert_consts.h"
 
 namespace KifConvertTools
 {
@@ -31,14 +30,14 @@ namespace KifConvertTools
 			}
 			auto inisfen = pos.sfen();
 			if (inisfen == SFEN_HIRATE)
-				std::cout << "position startpos moves";
+				ss << "position startpos moves";
 			else
-				std::cout << "position sfen " << inisfen << " moves";
+				ss << "position sfen " << inisfen << " moves";
 			while (states.size())
 			{
 				auto& top = states.top();
 				Move m = top->lastMove;
-				std::cout << " " << m;
+				ss << " " << m;
 				pos.do_move(m, *top);
 				states.pop();
 			}


### PR DESCRIPTION
- 文字列定数を `std::basic_string<charT>` から `charT *` に変更（バイナリサイズの低減）
- `to_sfen_string()` で `std::stringstream` オブジェクトにではなく `std::cout` に直接出力していた不具合の修正
