### PR TITLE
エンジンオプションによる探索制限

### DIFF
--- a/source/shogi.h
+++ b/source/shogi.h
@@ -526,9 +526,9 @@ std::ostream& operator<<(std::ostream& os, Piece pc);
 enum PieceNo : u8
 {
   PIECE_NO_PAWN = 0, PIECE_NO_LANCE = 18, PIECE_NO_KNIGHT = 22, PIECE_NO_SILVER = 26,
-  PIECE_NO_GOLD = 30, PIECE_NO_BISHOP = 34, PIECE_NO_ROOK = 36, PIECE_NO_KING = 38, 
+  PIECE_NO_GOLD = 30, PIECE_NO_BISHOP = 34, PIECE_NO_ROOK = 36, PIECE_NO_KING = 38,
   PIECE_NO_BKING = 38, PIECE_NO_WKING = 39, // 先手、後手の玉の番号が必要な場合はこっちを用いる
-  PIECE_NO_ZERO = 0, PIECE_NO_NB = 40, 
+  PIECE_NO_ZERO = 0, PIECE_NO_NB = 40,
 };
 
 // PieceNoの整合性の検査。assert用。
@@ -646,7 +646,7 @@ inline std::ostream& operator<<(std::ostream& os, ExtMove m) { os << m.move << '
 // 手駒
 // 歩の枚数を8bit、香、桂、銀、角、飛、金を4bitずつで持つ。こうすると16進数表示したときに綺麗に表示される。(なのはのアイデア)
 enum Hand : uint32_t { HAND_ZERO = 0, };
- 
+
 // 手駒のbit位置
 constexpr int PIECE_BITS[PIECE_HAND_NB] = { 0, 0 /*歩*/, 8 /*香*/, 12 /*桂*/, 16 /*銀*/, 20 /*角*/, 24 /*飛*/ , 28 /*金*/ };
 
@@ -906,8 +906,8 @@ namespace USI
 			defaultValue = currentValue = v ? "true" : "false";
 		}
 
-		// int型で(min,max)でデフォルトがv
-		Option(int v, int minv, int maxv, OnChange f = nullptr) : type("spin"), min(minv), max(maxv), on_change(f)
+		// long long型で(min,max)でデフォルトがv
+		Option(long long v, long long minv, long long maxv, OnChange f = nullptr) : type("spin"), min(minv), max(maxv), on_change(f)
 		{
 			defaultValue = currentValue = std::to_string(v);
 		}
@@ -926,17 +926,17 @@ namespace USI
 		// 起動時に設定を代入する。
 		void operator<<(const Option&);
 
-		// int,bool型への暗黙の変換子
-		operator int() const {
+		// long long,bool型への暗黙の変換子
+		operator long long() const {
 			ASSERT_LV1(type == "check" || type == "spin");
-			return type == "spin" ? stoi(currentValue) : currentValue == "true";
+			return type == "spin" ? stoll(currentValue) : currentValue == "true";
 		}
 
 		// string型への暗黙の変換子
 		// typeが"string"型のとき以外であっても何であれ変換できるようになっているほうが便利なので
 		// 変換できるようにしておく。
 		operator std::string() const {
-			ASSERT_LV1(type == "string" || type == "combo" || type == "spin" || type == "check"); 
+			ASSERT_LV1(type == "string" || type == "combo" || type == "spin" || type == "check");
 			return currentValue;
 		}
 
@@ -948,8 +948,8 @@ namespace USI
 
 		std::string defaultValue, currentValue, type;
 
-		// int型のときの最小と最大
-		int min, max;
+		// long long型のときの最小と最大
+		long long min, max;
 
 		// combo boxのときの表示する文字列リスト
 		std::vector<std::string> list;

--- a/source/usi.cpp
+++ b/source/usi.cpp
@@ -344,6 +344,12 @@ namespace USI
 		// 0なら無制限。(桁あふれすると良くないので内部的には100000として扱う)
 		o["MaxMovesToDraw"] << Option(0, 0, 100000, [](const Option& o) { max_game_ply = (o == 0) ? 100000 : (int)o; });
 
+		// 探索深さ制限。0なら無制限。
+		o["DepthLimit"] << Option(0, 0, INT_MAX);
+
+		// 探索ノード制限。0なら無制限。
+		o["NodesLimit"] << Option(0, 0, LLONG_MAX);
+
 		// 引き分けを受け入れるスコア
 		// 歩を100とする。例えば、この値を100にすると引き分けの局面は評価値が -100とみなされる。
 
@@ -378,7 +384,7 @@ namespace USI
 #if defined(LOCAL_GAME_SERVER)
 		// 子プロセスでEngineを実行するプロセッサグループ(Numa node)
 		// -1なら、指定なし。
-		o["EngineNuma"] << Option(-1, 0, 99999);
+		o["EngineNuma"] << Option(-1, -1, 99999);
 #endif
 
 		// 各エンジンがOptionを追加したいだろうから、コールバックする。
@@ -613,6 +619,10 @@ void go_cmd(const Position& pos, istringstream& is) {
 
 	// 終局(引き分け)になるまでの手数
 	limits.max_game_ply = max_game_ply;
+
+	// エンジンオプションによる探索制限(0なら無制限)
+	if (Options["DepthLimit"] >= 0)    limits.depth = Options["DepthLimit"];
+	if (Options["NodesLimit"] >= 0)    limits.nodes = Options["NodesLimit"];
 
 	while (is >> token)
 	{


### PR DESCRIPTION
GUI側で対応すべき所かは迷いどころですが、技巧をエンジンオプションで探索制限させて対局を行う人が一定数居るようですので、叩き台用に提案してみます。

- エンジンオプション `DepthLimit` , `NodesLimit` 追加
- `Option` の整数型を `int` から `long long` に型拡張 (`LLONG_MAX >= 9223372036854775807` とC++11規格で定義)
- エンジンオプション `EngineNuma` の最小値を `0` から `-1` に変更（`EngineNuma` のデフォルト値が `-1` だった）
