### PR TITLE
KPP KKPT評価関数のAVX2化

### DIFF
--- a/source/eval/evaluate_kpp_kkpt.cpp
+++ b/source/eval/evaluate_kpp_kkpt.cpp
@@ -433,6 +433,8 @@ namespace Eval
         // Nodes/second    : 784886
         // Function	Samples	% of Hotspot Samples	Module
         // Eval::do_a_pc(struct Position const &, struct Eval::ExtBonaPiece)	5870	11.9399996	YaneuraOu - 2017 - early.exe
+        //
+        // NPSが2.3%程度向上した
 
 #ifdef USE_AVX2
         __m256i sum0 = _mm256_setzero_si256();
@@ -586,8 +588,72 @@ namespace Eval
 				diff.p[1][0] = 0;
 				diff.p[1][1] = 0;
 
-				// ToDo : ここ、SSE2/SSE4/AVX2で最適化する。
+                // AVX2化前
+                // Nodes/second    : 793650
+                // Nodes/second    : 788538
+                // Nodes/second    : 784886
+                // Function	Samples	% of Hotspot Samples	Module
+                // Eval::evaluateBody(struct Position const &)	6195	12.5900002	YaneuraOu - 2017 - early.exe
+                // 
+                // AVX2化後
+                // Nodes/second    : 795766
+                // Nodes/second    : 788859
+                // Nodes/second    : 790836
+                // Function	Samples	% of Hotspot Samples	Module
+                // Eval::evaluateBody(struct Position const &)	6306	12.8400002	YaneuraOu - 2017 - early.exe
+                //
+                // NPSが0.3%程度しか向上しなかった
 
+#ifdef USE_AVX2
+                __m256i sum1_256 = _mm256_setzero_si256();
+                __m128i sum1_128 = _mm_setzero_si128();
+
+                for (int i = 0; i < PIECE_NO_KING; ++i)
+                {
+                    const int k1 = list1[i];
+                    const auto* pkppw = ppkppw[k1];
+                    int j = 0;
+                    for (; j + 8 < i; j += 8) {
+                        // 1要素が16-bitでvgatherdd命令が使えないため
+                        // 通常のメモリアクセスで評価値をロードする
+                        __m256i w1 = _mm256_set_epi32(
+                            pkppw[list1[j + 7]],
+                            pkppw[list1[j + 6]],
+                            pkppw[list1[j + 5]],
+                            pkppw[list1[j + 4]],
+                            pkppw[list1[j + 3]],
+                            pkppw[list1[j + 2]],
+                            pkppw[list1[j + 1]],
+                            pkppw[list1[j + 0]]);
+                        sum1_256 = _mm256_add_epi32(sum1_256, w1);
+                    }
+
+                    for (; j + 4 < i; j += 4) {
+                        __m128i w1 = _mm_set_epi32(
+                            pkppw[list1[j + 3]],
+                            pkppw[list1[j + 2]],
+                            pkppw[list1[j + 1]],
+                            pkppw[list1[j + 0]]);
+                        sum1_128 = _mm_add_epi32(sum1_128, w1);
+                    }
+
+                    for (; j < i; ++j) {
+                        diff.p[1][0] += pkppw[list1[j]];
+                    }
+
+                    // KKPのWK分。BKは移動していないから、BK側には影響ない。
+
+                    // 後手から見たKKP。後手から見ているのでマイナス
+                    diff.p[2][0] -= kkp[Inv(sq_wk)][Inv(sq_bk)][k1][0];
+                    // 後手から見たKKP手番。後手から見るのでマイナスだが、手番は先手から見たスコアを格納するのでさらにマイナスになって、プラス。
+                    diff.p[2][1] += kkp[Inv(sq_wk)][Inv(sq_bk)][k1][1];
+                }
+                sum1_128 = _mm_add_epi32(sum1_128, _mm256_extracti128_si256(sum1_256, 0));
+                sum1_128 = _mm_add_epi32(sum1_128, _mm256_extracti128_si256(sum1_256, 1));
+                sum1_128 = _mm_add_epi32(sum1_128, _mm_srli_si128(sum1_128, 8));
+                sum1_128 = _mm_add_epi32(sum1_128, _mm_srli_si128(sum1_128, 4));
+                diff.p[1][0] += _mm_extract_epi32(sum1_128, 0);
+#else
 				for (int i = 0; i < PIECE_NO_KING; ++i)
 				{
 					const int k1 = list1[i];
@@ -605,6 +671,7 @@ namespace Eval
 					// 後手から見たKKP手番。後手から見るのでマイナスだが、手番は先手から見たスコアを格納するのでさらにマイナスになって、プラス。
 					diff.p[2][1] += kkp[Inv(sq_wk)][Inv(sq_bk)][k1][1];
 				}
+#endif
 
 				// 動かした駒が２つ
 				if (moved_piece_num == 2)
@@ -629,18 +696,62 @@ namespace Eval
 				diff.p[0][0] = 0;
 				diff.p[0][1] = 0;
 
-				// ToDo : ここ、SSE2/SSE4/AVX2で最適化する。
+#ifdef USE_AVX2
+                __m256i sum0_256 = _mm256_setzero_si256();
+                __m128i sum0_128 = _mm_setzero_si128();
 
-				for (int i = 0; i < PIECE_NO_KING; ++i)
-				{
-					const int k0 = list0[i];
-					const auto* pkppb = ppkppb[k0];
-					for (int j = 0; j < i; ++j) {
-						const int l0 = list0[j];
-						diff.p[0][0] += pkppb[l0];
-					}
-					diff.p[2] += kkp[sq_bk][sq_wk][k0];
-				}
+                for (int i = 0; i < PIECE_NO_KING; ++i)
+                {
+                    const int k0 = list0[i];
+                    const auto* pkppb = ppkppb[k0];
+                    int j = 0;
+                    for (; j + 8 < i; j += 8) {
+                        // 1要素が16-bitでvgatherdd命令が使えないため
+                        // 通常のメモリアクセスで評価値をロードする
+                        __m256i w1 = _mm256_set_epi32(
+                            pkppb[list0[j + 7]],
+                            pkppb[list0[j + 6]],
+                            pkppb[list0[j + 5]],
+                            pkppb[list0[j + 4]],
+                            pkppb[list0[j + 3]],
+                            pkppb[list0[j + 2]],
+                            pkppb[list0[j + 1]],
+                            pkppb[list0[j + 0]]);
+                        sum0_256 = _mm256_add_epi32(sum0_256, w1);
+                    }
+
+                    for (; j + 4 < i; j += 4) {
+                        __m128i w1 = _mm_set_epi32(
+                            pkppb[list0[j + 3]],
+                            pkppb[list0[j + 2]],
+                            pkppb[list0[j + 1]],
+                            pkppb[list0[j + 0]]);
+                        sum0_128 = _mm_add_epi32(sum0_128, w1);
+                    }
+
+                    for (; j < i; ++j) {
+                        diff.p[0][0] += pkppb[list0[j]];
+                    }
+
+                    diff.p[2] += kkp[sq_bk][sq_wk][k0];
+                }
+                sum0_128 = _mm_add_epi32(sum0_128, _mm256_extracti128_si256(sum0_256, 0));
+                sum0_128 = _mm_add_epi32(sum0_128, _mm256_extracti128_si256(sum0_256, 1));
+                sum0_128 = _mm_add_epi32(sum0_128, _mm_srli_si128(sum0_128, 8));
+                sum0_128 = _mm_add_epi32(sum0_128, _mm_srli_si128(sum0_128, 4));
+                diff.p[0][0] += _mm_extract_epi32(sum0_128, 0);
+#else
+                for (int i = 0; i < PIECE_NO_KING; ++i)
+                {
+                    const int k0 = list0[i];
+                    const auto* pkppb = ppkppb[k0];
+                    for (int j = 0; j < i; ++j) {
+                        const int l0 = list0[j];
+                        diff.p[0][0] += pkppb[l0];
+                    }
+                    diff.p[2] += kkp[sq_bk][sq_wk][k0];
+                }
+#endif
 
 				if (moved_piece_num == 2) {
 					const int listIndex_cap = dp.pieceNo[1];


### PR DESCRIPTION
KPP KKPT評価関数をAVX2化するプルリクエストをさせていただきます。パフォーマンスプロファイラでホットスポットと判定されたdo_a_pc()とevaluateBody()をAVX2化しています。2ヶ所の変更で、計2.6%程度高速化しました。vgatherdd命令が使えないため、KPPT評価関数に比べ速度向上は小さくなっています。