### PR TITLE
各種評価関数のchecksumを追加

### DIFF
--- a/source/eval/evaluate.cpp
+++ b/source/eval/evaluate.cpp
@@ -66,6 +66,7 @@ namespace Eval
 
 		// ソフト名自動判別
 		std::map<u64, std::string> list = {
+			{ 0x0000d6799926233 , "ShinYane(20161010)"    } , // 真やねうら王
 			{ 0x0000da0f36d1b4b , "Apery(WCSC26)"         } , // Apery(WCSC26)
 			{ 0x0000d7213c45779 , "Ukamuse(sdt4)"         } , // 浮かむ瀬     = Apery(sdt4)
 
@@ -74,8 +75,26 @@ namespace Eval
 			{ 0x0000d5214c4e6d8 , "Qhapaq(WCSC27)"        } , // Qhapaq(WCSC27)
 			{ 0x0000d291a9942bb , "tanuki(WCSC27)"        } , // tanuki(WCSC27)
 
+			{ 0x000000000000000 , "rezero epoch0"         } , // リゼロ評価関数epoch0
+			{ 0x00008b66a4ecea9 , "rezero epoch0.1"       } , // リゼロ評価関数epoch0.1
+			{ 0x000093a87cc91ad , "rezero epoch1"         } , // リゼロ評価関数epoch1
+			{ 0x000096a5706b9ec , "rezero epoch2"         } , // リゼロ評価関数epoch2
+			{ 0x000096b3df75de8 , "rezero epoch3"         } , // リゼロ評価関数epoch3
+			{ 0x0000964a98dc84b , "rezero epoch4"         } , // リゼロ評価関数epoch4
+			{ 0x000095f8443a079 , "rezero epoch5"         } , // リゼロ評価関数epoch5
+			{ 0x0000953fbdc48d6 , "rezero epoch6"         } , // リゼロ評価関数epoch6
+			{ 0x0000a4896775602 , "rezero epoch7"         } , // リゼロ評価関数epoch7
 			{ 0x0000a516345897e , "rezero epoch8"         } , // リゼロ評価関数epoch8
-			{ 0x0000a6fbc5087ce , "yaseiyomita(20170703)" } , // 野生の読みの太(20170703)
+			{ 0x0000a6eea7db958 , "yaseiyomita(20170626)" } , // 野生の読み太(20170626)
+			{ 0x0000a6fbc5087ce , "yaseiyomita(20170703)" } , // 野生の読み太(20170703)
+			{ 0x0000a63c328ca42 , "yaseiyomita(20170802)" } , // 野生の読み太(20170802)
+			{ 0x0000c8e89414b88 , "elmoqhapaq ver1.0"     } , // elmo-qhapaq version 1.0
+			{ 0x0000c8ac0b10c78 , "elmoqhapaq ver1.1"     } , // elmo-qhapaq version 1.1
+
+			{ 0x0000c62cf4f6b91 , "relmo8"                } , // リゼロ評価関数epoch8とelmo(WCSC27)を1:1でブレンド
+			{ 0x0000c85005252ee , "yaselmo(20170705)"     } , // 野生の読み太(20170703)とelmo(WCSC27)を1:1でブレンド
+
+			{ 0x0000574a685513c , "kppkkpt rezero epoch4" } , // KPP_KKPT型リゼロ評価関数epoch4
 
 			// ここに加えて欲しい評価関数があれば、
 			// "isready"コマンドに対する応答時に表示されるcheck sumの値を連絡ください(｀･ω･´)ｂ


### PR DESCRIPTION
評価関数のchecksumを追加しました。
* 真やねうら王
* リゼロepoch0～7
* 野生の読み太(20170626)
* 野生の読み太(20170802)
* elmo-qhapaq version 1.0
* elmo-qhapaq version 1.1
* relmo8
* yaselmo(20170705)
* KPP_KKPT型リゼロepoch4

また、誤字を修正しました。