### PR TITLE
Yane qhapaq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ YaneuraOu_backup*.lnk
 *.bak
 *Private.*
 *.vspx
+*~
+~*
 
 # experimental
 

--- a/source/Makefile
+++ b/source/Makefile
@@ -6,8 +6,8 @@ YANEURAOU_EDITION = YANEURAOU_2017_EARLY_ENGINE
 
 
 # clangでコンパイルしたほうがgccより数%速いっぽい。
-# COMPILER = g++
-COMPILER = clang++
+COMPILER = g++
+#COMPILER = clang++
 
 # 標準的なコンパイルオプション
 CFLAGS   = -std=c++14 -fno-exceptions -fno-rtti -Wextra -Ofast -MMD -MP -fpermissive

--- a/source/extra/book/book.cpp
+++ b/source/extra/book/book.cpp
@@ -1232,6 +1232,9 @@ namespace Book
 		// 定跡の指し手を何手目まで用いるか
 		o["BookMoves"] << Option(16, 0, 10000);
 
+		// 一定の確率で定跡を無視して自力で思考させる
+		o["BookIgnoreRate"] << Option(0, 0, 100);
+
 		// 定跡ファイル名
 
 		//  no_book          定跡なし
@@ -1274,6 +1277,11 @@ namespace Book
 	// probe()の下請け
 	bool BookMoveSelector::probe_impl(Position& rootPos, bool silent , Move& bestMove , Move& ponderMove)
 	{
+		// 一定確率で定跡を無視
+	        if ( (int)Options["BookIgnoreRate"] > prng.rand(100)){
+			return false;		 
+	        }
+	  
 		// 定跡を用いる手数
 		int book_ply = (int)Options["BookMoves"];
 		if (rootPos.game_ply() > book_ply)

--- a/source/learn/learner.cpp
+++ b/source/learn/learner.cpp
@@ -2169,6 +2169,89 @@ void shuffle_files_on_memory(const vector<string>& filenames,const string output
 	std::cout << "..shuffle_on_memory done." << std::endl;
 }
 
+void convert_bin(const vector<string>& filenames , const string& output_file_name)
+{
+  fstream fs;
+  auto th = Threads.main();
+  auto &tpos = th->rootPos;
+  // plain形式の雑巾をやねうら王用のpackedsfenvalueに変換する
+  fs.open(output_file_name, ios::app | ios::binary);
+  
+  for(auto filename : filenames){
+    std::cout<<"convert "<<filename<<" ... ";
+    std::string line;
+    ifstream ifs;
+    ifs.open(filename);
+    PackedSfenValue p;
+    while(std::getline(ifs,line)){
+      std::stringstream ss(line);
+      std::string token;
+      std::string value;
+      ss >> token;
+      if(token == "sfen"){
+	StateInfo si;
+	tpos.set(line.substr(5), &si , Threads.main());
+	tpos.sfen_pack(p.sfen);
+      }else if(token == "move"){
+	ss >> value;
+	p.move = move_from_usi(value);
+      }else if(token == "score"){
+	ss >> p.score;
+      }else if(token == "ply"){
+	int temp;
+	ss >> temp;
+	p.gamePly = u16(temp); // 此処のキャストいらない？
+      }else if(token == "result"){
+	int temp;
+	ss >> temp;
+	p.game_result = s8(temp); // 此処のキャストいらない？
+      }else if(token == "e"){
+	fs.write((char*)&p, sizeof(PackedSfenValue));
+	// debug
+	/*
+	std::cout<<tpos<<std::endl;
+	std::cout<<to_usi_string(Move(p.move))<<","<<p.score<<","<<int(p.gamePly)<<","<<int(p.game_result)<<std::endl;
+	*/
+      }
+    }
+    std::cout<<"done"<<std::endl;
+    ifs.close();
+  }
+  std::cout<<"all done"<<std::endl;
+  fs.close();
+}
+  
+void convert_plain(const vector<string>& filenames , const string& output_file_name)
+{
+  Position tpos;
+  ofstream ofs;
+  ofs.open(output_file_name, ios::app);
+  for(auto filename : filenames){
+    std::cout<<"convert "<<filename<<" ... ";
+    // 只管packedsfenvalueをテキストに変換する
+    fstream fs;
+    
+    fs.open(filename, ios::in | ios::binary);
+    PackedSfenValue p;
+    while(1){
+      if (fs.read((char*)&p, sizeof(PackedSfenValue))){
+	// plain textとして書き込む
+	ofs <<"sfen "<< tpos.sfen_unpack(p.sfen)<<std::endl;
+	ofs <<"move "<< to_usi_string(Move(p.move))<<std::endl;
+	ofs <<"score "<< p.score<<std::endl;
+	ofs <<"ply "<< int(p.gamePly)<<std::endl;
+	ofs <<"result "<< int(p.game_result)<<std::endl;
+	ofs <<"e"<<std::endl;
+      }else{
+	break;
+      }
+    }
+    fs.close();
+    std::cout<<"done"<<std::endl;
+  }
+  ofs.close();
+  std::cout<<"all done"<<std::endl;
+}
 
 // 生成した棋譜からの学習
 void learn(Position&, istringstream& is)
@@ -2215,6 +2298,10 @@ void learn(Position&, istringstream& is)
 	bool shuffle_quick = false;
 	// メモリにファイルを丸読みしてシャッフルする機能。(要、ファイルサイズのメモリ)
 	bool shuffle_on_memory = false;
+	// packed sfenの変換。plainではsfen(string), 評価値(整数), 指し手(例：7g7f, string)、結果(負け-1、勝ち1、引き分け0)からなる
+	bool use_convert_plain = false;
+	// plain形式の教師をやねうら王のbinに変換する
+	bool use_convert_bin = false;
 	// それらのときに書き出すファイル名(デフォルトでは"shuffled_sfen.bin")
 	string output_file_name = "shuffled_sfen.bin";
 
@@ -2317,7 +2404,10 @@ void learn(Position&, istringstream& is)
 		else if (option == "eval_limit") is >> eval_limit;
 		else if (option == "save_only_once") save_only_once = true;
 		else if (option == "no_shuffle") no_shuffle = true;
-
+		
+		// 雑巾のconvert関連
+		else if (option == "convert_plain") use_convert_plain = true;
+		else if (option == "convert_bin") use_convert_bin = true;
 		// さもなくば、それはファイル名である。
 		else
 			filenames.push_back(option);
@@ -2401,6 +2491,20 @@ void learn(Position&, istringstream& is)
 		cout << "shuffle on memory.." << endl;
 		shuffle_files_on_memory(filenames,output_file_name);
 		return;
+	}
+	if (use_convert_plain)
+	{
+		cout << "convert_plain.." << endl;
+		convert_plain(filenames,output_file_name);
+		return;
+		
+	}
+	if (use_convert_bin)
+	{
+		cout << "convert_bin.." << endl;
+		convert_bin(filenames,output_file_name);
+		return;
+		
 	}
 
 	cout << "loop              : " << loop << endl;

--- a/source/learn/learner.cpp
+++ b/source/learn/learner.cpp
@@ -2183,35 +2183,36 @@ void convert_bin(const vector<string>& filenames , const string& output_file_nam
     ifstream ifs;
     ifs.open(filename);
     PackedSfenValue p;
+    p.gamePly = 1; // apery形式では含まれない。一応初期化するべし
     while(std::getline(ifs,line)){
       std::stringstream ss(line);
       std::string token;
       std::string value;
       ss >> token;
       if(token == "sfen"){
-	StateInfo si;
-	tpos.set(line.substr(5), &si , Threads.main());
-	tpos.sfen_pack(p.sfen);
+        StateInfo si;
+        tpos.set(line.substr(5), &si , Threads.main());
+        tpos.sfen_pack(p.sfen);
       }else if(token == "move"){
-	ss >> value;
-	p.move = move_from_usi(value);
+        ss >> value;
+        p.move = move_from_usi(value);
       }else if(token == "score"){
-	ss >> p.score;
+        ss >> p.score;
       }else if(token == "ply"){
-	int temp;
-	ss >> temp;
-	p.gamePly = u16(temp); // 此処のキャストいらない？
+        int temp;
+        ss >> temp;
+        p.gamePly = u16(temp); // 此処のキャストいらない？
       }else if(token == "result"){
-	int temp;
-	ss >> temp;
-	p.game_result = s8(temp); // 此処のキャストいらない？
+        int temp;
+        ss >> temp;
+        p.game_result = s8(temp); // 此処のキャストいらない？
       }else if(token == "e"){
-	fs.write((char*)&p, sizeof(PackedSfenValue));
-	// debug
-	/*
-	std::cout<<tpos<<std::endl;
-	std::cout<<to_usi_string(Move(p.move))<<","<<p.score<<","<<int(p.gamePly)<<","<<int(p.game_result)<<std::endl;
-	*/
+        fs.write((char*)&p, sizeof(PackedSfenValue));
+        // debug
+        /*
+          std::cout<<tpos<<std::endl;
+          std::cout<<to_usi_string(Move(p.move))<<","<<p.score<<","<<int(p.gamePly)<<","<<int(p.game_result)<<std::endl;
+        */
       }
     }
     std::cout<<"done"<<std::endl;
@@ -2494,6 +2495,7 @@ void learn(Position&, istringstream& is)
 	}
 	if (use_convert_plain)
 	{
+	  	is_ready(true);
 		cout << "convert_plain.." << endl;
 		convert_plain(filenames,output_file_name);
 		return;
@@ -2501,6 +2503,7 @@ void learn(Position&, istringstream& is)
 	}
 	if (use_convert_bin)
 	{
+	  	is_ready(true);
 		cout << "convert_bin.." << endl;
 		convert_bin(filenames,output_file_name);
 		return;


### PR DESCRIPTION
learner.cpp
教師データの変換器を実装しました。仕様の詳細は
http://qhapaq.hatenablog.com/entry/2017/12/25/002820
を参照してください。

book.cpp
BookIgnoreRate を追加
定跡の穴を見つける際に、一定の確率で定跡の手を不採択にする手が有効である（私調べ）
ので、やねうら王の標準機能にどうでしょう

.gitignore
Makefile
これらの変更は不要だと思います（此方のローカルの開発事情に起因してるので）