### PR TITLE
Buildfiles

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,0 +1,119 @@
+# Copyright (C) 2009 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+ARCH_DEF := -DTARGET_ARCH="$(TARGET_ARCH_ABI)"
+
+ENGINE_TARGET := YANEURAOU_2018_OTAFUKU_ENGINE
+#ENGINE_TARGET := YANEURAOU_2018_TNK_ENGINE
+
+ifeq ($(ENGINE_TARGET),YANEURAOU_2018_OTAFUKU_ENGINE)
+  ARCH_DEF += -DUSE_MAKEFILE -DYANEURAOU_2018_OTAFUKU_ENGINE
+  ENGINE_NAME := YaneuraOu2018otafuku
+endif
+
+ifeq ($(ENGINE_TARGET),YANEURAOU_2018_TNK_ENGINE)
+  ARCH_DEF += -DUSE_MAKEFILE -DYANEURAOU_2018_TNK_ENGINE
+  ENGINE_NAME := YaneuraOu2018tnk
+endif
+
+ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
+  ARCH_DEF += -DIS_64BIT -DIS_ARM
+endif
+
+ifeq ($(TARGET_ARCH_ABI),x86_64)
+  ARCH_DEF += -DUSE_SSE42 -msse4.2
+endif
+
+ifeq ($(TARGET_ARCH_ABI),x86)
+  ARCH_DEF += 
+endif
+
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+  ARCH_DEF += -DIS_ARM
+endif
+
+LOCAL_MODULE    := $(ENGINE_NAME)-$(TARGET_ARCH_ABI)
+LOCAL_CXXFLAGS  := -std=c++14 -fno-exceptions -fno-rtti -Wextra -Ofast -MMD -MP -fpermissive -D__STDINT_MACROS -D__STDC_LIMIT_MACROS $(ARCH_DEF)
+LOCAL_CXXFLAGS += -fPIE -Wno-unused-parameter
+LOCAL_LDFLAGS += -fPIE -pie -flto
+LOCAL_LDLIBS = 
+LOCAL_C_INCLUDES := 
+LOCAL_CPP_FEATURES += exceptions rtti
+#LOCAL_STATIC_LIBRARIES    := -lpthread
+
+LOCAL_SRC_FILES := \
+  ../source/shogi.cpp                                                  \
+  ../source/bitboard.cpp                                               \
+  ../source/misc.cpp                                                   \
+  ../source/movegen.cpp                                                \
+  ../source/position.cpp                                               \
+  ../source/usi.cpp                                                    \
+  ../source/thread.cpp                                                 \
+  ../source/tt.cpp                                                     \
+  ../source/move_picker.cpp                                            \
+  ../source/extra/book/apery_book.cpp                                  \
+  ../source/extra/book/book.cpp                                        \
+  ../source/extra/bitop.cpp                                            \
+  ../source/extra/entering_king_win.cpp                                \
+  ../source/extra/long_effect.cpp                                      \
+  ../source/extra/mate/mate1ply_with_effect.cpp                        \
+  ../source/extra/mate/mate1ply_without_effect.cpp                     \
+  ../source/extra/mate/mate_n_ply.cpp                                  \
+  ../source/extra/benchmark.cpp                                        \
+  ../source/extra/test_cmd.cpp                                         \
+  ../source/extra/timeman.cpp                                          \
+  ../source/extra/see.cpp                                              \
+  ../source/extra/sfen_packer.cpp                                      \
+  ../source/extra/kif_converter/kif_convert_tools.cpp                  \
+  ../source/eval/evaluate_bona_piece.cpp                               \
+  ../source/eval/kppt/evaluate_kppt.cpp                                \
+  ../source/eval/kppt/evaluate_kppt_learner.cpp                        \
+  ../source/eval/kpp_kkpt/evaluate_kpp_kkpt.cpp                        \
+  ../source/eval/kpp_kkpt/evaluate_kpp_kkpt_learner.cpp                \
+  ../source/eval/kpppt/evaluate_kpppt.cpp                              \
+  ../source/eval/kpppt/evaluate_kpppt_learner.cpp                      \
+  ../source/eval/kppp_kkpt/evaluate_kppp_kkpt.cpp                      \
+  ../source/eval/kppp_kkpt/evaluate_kppp_kkpt_learner.cpp              \
+  ../source/eval/kkpp_kkpt/evaluate_kkpp_kkpt.cpp                      \
+  ../source/eval/kkpp_kkpt/evaluate_kkpp_kkpt_learner.cpp              \
+  ../source/eval/kkppt/evaluate_kkppt.cpp                              \
+  ../source/eval/kkppt/evaluate_kkppt_learner.cpp                      \
+  ../source/eval/kpp_kkpt_fv_var/evaluate_kpp_kkpt_fv_var.cpp          \
+  ../source/eval/kpp_kkpt_fv_var/evaluate_kpp_kkpt_fv_var_learner.cpp  \
+  ../source/eval/evaluate.cpp                                          \
+  ../source/eval/evaluate_io.cpp                                       \
+  ../source/eval/evaluate_mir_inv_tools.cpp                            \
+  ../source/engine/user-engine/user-search.cpp                         \
+  ../source/engine/help-mate-engine/help-mate-search.cpp               \
+  ../source/engine/2018-otafuku-engine/2018-otafuku-search.cpp         \
+  ../source/learn/learner.cpp                                          \
+  ../source/learn/learning_tools.cpp                                   \
+  ../source/learn/multi_think.cpp
+
+ifeq ($(ENGINE_TARGET),YANEURAOU_2018_TNK_ENGINE)
+LOCAL_SRC_FILES += \
+  ../source/eval/nnue/evaluate_nnue.cpp                                \
+  ../source/eval/nnue/evaluate_nnue_learner.cpp                        \
+  ../source/eval/nnue/nnue_test_command.cpp                            \
+  ../source/eval/nnue/features/k.cpp                                   \
+  ../source/eval/nnue/features/p.cpp                                   \
+  ../source/eval/nnue/features/half_kp.cpp                             \
+  ../source/eval/nnue/features/half_relative_kp.cpp
+endif
+
+include $(BUILD_EXECUTABLE)

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -32,7 +32,8 @@ ifeq ($(ENGINE_TARGET),YANEURAOU_2018_TNK_ENGINE)
 endif
 
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
-  ARCH_DEF += -DIS_64BIT -DIS_ARM
+  ARCH_DEF += -DIS_64BIT -DIS_ARM -mfpu=neon
+  LOCAL_ARM_NEON := true
 endif
 
 ifeq ($(TARGET_ARCH_ABI),x86_64)
@@ -44,7 +45,8 @@ ifeq ($(TARGET_ARCH_ABI),x86)
 endif
 
 ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
-  ARCH_DEF += -DIS_ARM
+  ARCH_DEF += -DIS_ARM -mfpu=neon
+  LOCAL_ARM_NEON := true
 endif
 
 LOCAL_MODULE    := $(ENGINE_NAME)-$(TARGET_ARCH_ABI)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,0 +1,4 @@
+#APP_ABI := x86 armeabi-v7a
+APP_ABI := arm64-v8a x86_64
+APP_STL:=c++_static
+APP_PLATFORM = android-16

--- a/script/linux_build.sh
+++ b/script/linux_build.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Ubuntu 上で Linux バイナリのビルド
+MAKE=make
+MAKEFILE=Makefile
+JOBS=`grep -c ^processor /proc/cpuinfo 2>/dev/null`
+
+cd `dirname $0`
+cd ../source
+
+# Bash on Windows (Ubuntu 18.04 Bionic) 環境の場合は http://apt.llvm.org/ を参考に clang++-7 を導入する。
+# sudo apt install build-essential clang-7 lldb-7 lld-7
+COMPILER=clang++-7
+BUILDDIR=../build/2018otafuku
+mkdir -p ${BUILDDIR}
+EDITION=YANEURAOU_2018_OTAFUKU_ENGINE
+TARGET=YaneuraOu-2018-otafuku-linux-clang
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [evallearn]=-evallearn-avx2 [evallearn-sse42]=-evallearn-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc ${BUILDDIR}/${TARGET}${TGTAIL[$key]}
+done
+
+# Bash on Windows (Ubuntu 18.04 Bionic) 環境の場合は http://apt.llvm.org/ を参考に clang++-7 を導入する。
+# sudo apt install build-essential clang-7 lldb-7 lld-7
+COMPILER=clang++-7
+BUILDDIR=../build/2018tnk
+mkdir -p ${BUILDDIR}
+EDITION=YANEURAOU_2018_TNK_ENGINE
+TARGET=YaneuraOu-2018-tnk-linux-clang
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [evallearn]=-evallearn-avx2 [evallearn-sse42]=-evallearn-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc ${BUILDDIR}/${TARGET}${TGTAIL[$key]}
+done
+
+# Bash on Windows (Ubuntu 18.04 Bionic) 環境の場合は http://apt.llvm.org/ を参考に clang++-7 を導入する。
+# sudo apt install build-essential clang-7 lldb-7 lld-7
+COMPILER=clang++-7
+BUILDDIR=../build/mate
+mkdir -p ${BUILDDIR}
+EDITION=YANEURAOU_MATE_ENGINE
+TARGET=YaneuraOu-mate-linux-clang
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc ${BUILDDIR}/${TARGET}${TGTAIL[$key]}
+done
+
+# ここでは、 https://launchpad.net/~jonathonf/+archive/ubuntu/gcc より g++-8 を導入してビルドに用いる。
+# sudo add-apt-repository ppa:jonathonf/gcc
+# sudo apt update
+# sudo apt install g++-8
+COMPILER=g++-8
+BUILDDIR=../build/2018otafuku
+mkdir -p ${BUILDDIR}
+EDITION=YANEURAOU_2018_OTAFUKU_ENGINE
+TARGET=YaneuraOu-2018-otafuku-linux-gcc
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [evallearn]=-evallearn-avx2 [evallearn-sse42]=-evallearn-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc ${BUILDDIR}/${TARGET}${TGTAIL[$key]}
+done
+
+# ここでは、 https://launchpad.net/~jonathonf/+archive/ubuntu/gcc より g++-8 を導入してビルドに用いる。
+# sudo add-apt-repository ppa:jonathonf/gcc
+# sudo apt update
+# sudo apt install g++-8
+COMPILER=g++-8
+BUILDDIR=../build/2018tnk
+mkdir -p ${BUILDDIR}
+EDITION=YANEURAOU_2018_TNK_ENGINE
+TARGET=YaneuraOu-2018-tnk-linux-gcc
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [evallearn]=-evallearn-avx2 [evallearn-sse42]=-evallearn-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc ${BUILDDIR}/${TARGET}${TGTAIL[$key]}
+done
+
+# ここでは、 https://launchpad.net/~jonathonf/+archive/ubuntu/gcc より g++-8 を導入してビルドに用いる。
+# sudo add-apt-repository ppa:jonathonf/gcc
+# sudo apt update
+# sudo apt install g++-8
+COMPILER=g++-8
+BUILDDIR=../build/mate
+mkdir -p ${BUILDDIR}
+EDITION=YANEURAOU_MATE_ENGINE
+TARGET=YaneuraOu-mate-linux-gcc
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [evallearn]=-evallearn-avx2 [evallearn-sse42]=-evallearn-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc ${BUILDDIR}/${TARGET}${TGTAIL[$key]}
+done
+
+${MAKE} -f ${MAKEFILE} clean

--- a/script/mingw_gcc.sh
+++ b/script/mingw_gcc.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Ubuntu 上で Windows バイナリのビルド (gcc)
+OS=Windows_NT
+MAKE=make
+MAKEFILE=Makefile
+JOBS=`grep -c ^processor /proc/cpuinfo 2>/dev/null`
+
+cd `dirname $0`
+cd ../source
+
+# sudo apt install build-essential mingw-w64
+COMPILER=x86_64-w64-mingw32-g++-posix
+
+BUILDDIR=../build/2018otafuku
+mkdir -p ${BUILDDIR}
+EDITION=YANEURAOU_2018_OTAFUKU_ENGINE
+TARGET=YaneuraOu-2018-otafuku-mingw-gcc
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [evallearn]=-evallearn-avx2 [evallearn-sse42]=-evallearn-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} OS=${OS} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TARGET}${TGTAIL[$key]}.exe
+done
+
+BUILDDIR=../build/2018tnk
+mkdir -p ${BUILDDIR}
+EDITION=YANEURAOU_2018_TNK_ENGINE
+TARGET=YaneuraOu-2018-tnk-mingw-gcc
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [evallearn]=-evallearn-avx2 [evallearn-sse42]=-evallearn-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} OS=${OS} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TARGET}${TGTAIL[$key]}.exe
+done
+
+BUILDDIR=../build/mate
+mkdir -p ${BUILDDIR}
+EDITION=YANEURAOU_MATE_ENGINE
+TARGET=YaneuraOu-mate-mingw-gcc
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [evallearn]=-evallearn-avx2 [evallearn-sse42]=-evallearn-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} OS=${OS} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TARGET}${TGTAIL[$key]}.exe
+done
+
+${MAKE} -f ${MAKEFILE} clean

--- a/script/msys2_build.sh
+++ b/script/msys2_build.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/bash
+# -*- coding: utf-8 -*-
+# MSYS2 上で Windows バイナリのビルド
+OS=Windows_NT
+MAKE=mingw32-make
+MAKEFILE=Makefile
+JOBS=`grep -c ^processor /proc/cpuinfo 2>/dev/null`
+
+cd `dirname $0`
+cd ../source
+
+COMPILER=clang++
+BUILDDIR=../build/2018otafuku
+mkdir -p ${BUILDDIR}
+EDITION=YANEURAOU_2018_OTAFUKU_ENGINE
+TARGET=YaneuraOu-2018-otafuku-msys2-clang
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [evallearn]=-evallearn-avx2 [evallearn-sse42]=-evallearn-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} OS=${OS} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TARGET}${TGTAIL[$key]}.exe
+done
+
+COMPILER=clang++
+BUILDDIR=../build/2018tnk
+mkdir -p ${BUILDDIR}
+EDITION=YANEURAOU_2018_TNK_ENGINE
+TARGET=YaneuraOu-2018-tnk-msys2-clang
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [evallearn]=-evallearn-avx2 [evallearn-sse42]=-evallearn-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} OS=${OS} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TARGET}${TGTAIL[$key]}.exe
+done
+
+COMPILER=clang++
+BUILDDIR=../build/mate
+mkdir -p ${BUILDDIR}
+EDITION=MATE_ENGINE
+TARGET=YaneuraOu-mate-msys2-clang
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} OS=${OS} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TARGET}${TGTAIL[$key]}.exe
+done
+
+COMPILER=g++
+BUILDDIR=../build/2018Otafuku
+mkdir -p ${BUILDDIR}
+EDITION=YANEURAOU_2018_OTAFUKU_ENGINE
+TARGET=YaneuraOu-2018-otafuku-msys2-gcc
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [evallearn]=-evallearn-avx2 [evallearn-sse42]=-evallearn-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} OS=${OS} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TARGET}${TGTAIL[$key]}.exe
+done
+
+COMPILER=g++
+BUILDDIR=../build/2018tnk
+mkdir -p ${BUILDDIR}
+EDITION=YANEURAOU_2018_TNK_ENGINE
+TARGET=YaneuraOu-2018-tnk-msys2-gcc
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [evallearn]=-evallearn-avx2 [evallearn-sse42]=-evallearn-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} OS=${OS} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TARGET}${TGTAIL[$key]}.exe
+done
+
+COMPILER=g++
+BUILDDIR=../build/mate
+mkdir -p ${BUILDDIR}
+EDITION=MATE_ENGINE
+TARGET=YaneuraOu-mate-msys2-gcc
+declare -A TGTAIL=([avx2]=-avx2 [sse42]=-sse42 [tournament]=-tournament-avx2 [tournament-sse42]=-tournament-sse42 [sse41]=-sse41 [sse2]=-sse2)
+for key in ${!TGTAIL[*]}
+do
+	${MAKE} -f ${MAKEFILE} clean
+	${MAKE} -f ${MAKEFILE} -j${JOBS} ${key} YANEURAOU_EDITION=${EDITION} COMPILER=${COMPILER} OS=${OS} 2>&1 | tee $BUILDDIR/${TARGET}${TGTAIL[$key]}.log
+	cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TARGET}${TGTAIL[$key]}.exe
+done
+
+${MAKE} -f ${MAKEFILE} clean

--- a/source/extra/bitop.h
+++ b/source/extra/bitop.h
@@ -22,8 +22,11 @@
 #include <nmmintrin.h>
 #elif defined(USE_SSE41)
 #include <smmintrin.h>
-#elif defined (USE_SSE2)
+#elif defined(USE_SSE2)
 #include <emmintrin.h>
+#elif defined(IS_ARM)
+#include <arm_neon.h>
+#include <mm_malloc.h> // for _mm_alloc()
 #else
 #if defined (__GNUC__) 
 #include <mm_malloc.h> // for _mm_alloc()
@@ -158,7 +161,7 @@ FORCE_INLINE int MSB32(uint32_t v) { ASSERT_LV3(v != 0); unsigned long index; _B
 FORCE_INLINE int MSB64(uint64_t v) { ASSERT_LV3(v != 0); return uint32_t(v >> 32) ? 32 + MSB32(uint32_t(v >> 32)) : MSB32(uint32_t(v)); }
 #endif
 
-#elif defined(__GNUC__) && ( defined(__i386__) || defined(__x86_64__) )
+#elif defined(__GNUC__) && ( defined(__i386__) || defined(__x86_64__) || defined(__ANDROID__) )
 
 FORCE_INLINE int LSB32(const u32 v) { ASSERT_LV3(v != 0); return __builtin_ctzll(v); }
 FORCE_INLINE int LSB64(const u64 v) { ASSERT_LV3(v != 0); return __builtin_ctzll(v); }

--- a/source/extra/config.h
+++ b/source/extra/config.h
@@ -622,9 +622,11 @@ constexpr bool pretty_jp = false;
 // ----------------------------
 
 // ターゲットが64bitOSかどうか
-#if (defined(_WIN64) && defined(_MSC_VER)) || (defined(__GNUC__) && defined(__x86_64__))
+#if (defined(_WIN64) && defined(_MSC_VER)) || (defined(__GNUC__) && defined(__x86_64__)) || defined(IS_64BIT)
 constexpr bool Is64Bit = true;
+#ifndef IS_64BIT
 #define IS_64BIT
+#endif
 #else
 constexpr bool Is64Bit = false;
 #endif


### PR DESCRIPTION
各種環境のビルドものです。

- `script/msys2_build.sh`
MSYS2 64bit用バッチビルドスクリプトです。
g++ , clang++ でWindows用各種バイナリを `build/` 以下にバッチ生成します。
- `script/mingw_gcc.sh`
Linux (Ubuntu 18.04) mingw-w64 用バッチビルドスクリプトです。
g++ でWindows用各種バイナリを `build/` 以下にバッチ生成します。
- `script/linux_build.sh`
Linux (Ubuntu 18.04) 用バッチビルドスクリプトです。
g++8 , clang++-7 でLinux用各種バイナリを `build/` 以下にバッチ生成します。
- `jni/*.mk`
https://github.com/ai5/YaneuraOu/tree/android/ を元に作成しました。
Android NDK用ビルド設定です。Android arm64-v8a , x86_64 用バイナリを `libs/` 以下に生成します。
生成バイナリ例: https://github.com/mizar/YaneuraOu/releases/tag/v4.82-master%2B20180517.build2
ここで生成されたバイナリは、[ShogiDroid](http://shogidroid.siganus.com/)上での実行を想定しています。
Android NDK を導入、 `(Android SDKインストール先)\Sdk\ndk-bundle` などにPATHを通し、
シェル上で `YaneuraOu/` をカレントディレクトリとして、
`$ ndk-build ENGINE_TARGET=YANEURAOU_2018_OTAFUKU_ENGINE`
`$ ndk-build ENGINE_TARGET=YANEURAOU_2018_TNK_ENGINE`
とするか、`jni/Android.mk`を適宜変更して
`$ ndk-build`
としてビルドを実行します。
arm64-v8a向けSIMD命令の明示的な使用までは着手していないので、arm64-v8a での探索速度を改善するにはその（ソースコード上で `USE_AVX2` や `USE_SSE*` などで分岐処理している）辺りを書き足す手もあるかもしれません。
※ Android端末のABI (arm64-v8a , x86_64)を特定するには、端末のコマンドライン上から以下のように実行する方法があります。
`$ getprop | grep cpu`