### PR TITLE
探索が開始しないバグを修正した

### DIFF
--- a/source/engine/mate-engine/mate-search.cpp
+++ b/source/engine/mate-engine/mate-search.cpp
@@ -459,6 +459,8 @@ namespace MateEngine
 
 	// 詰将棋探索のエントリポイント
 	void dfpn(Position& r) {
+        Threads.stop = false;
+
 		if (r.in_check()) {
 			// 逆王手からの詰みは対応しないので、notimplementedを返す.
 			sync_cout << "info string The king is checked... df-pn is skipped..." << sync_endl;


### PR DESCRIPTION
go mateコマンド実行時に探索が始まらないバグを修正しました。

よろしくお願いいたします。
