### PR TITLE
Mate engine loop 2018 05 24

### DIFF
--- a/source/engine/mate-engine/mate-search.cpp
+++ b/source/engine/mate-engine/mate-search.cpp
@@ -253,6 +253,37 @@ namespace MateEngine
 			return;
 		}
 
+		auto draw_type = n.is_repetition(n.game_ply());
+		switch (draw_type) {
+		case REPETITION_WIN:
+			if (or_node) {
+				// ここは通らないはず
+				entry.pn = 0;
+				entry.dn = kInfinitePnDn;
+				entry.minimum_distance = std::min(entry.minimum_distance, depth);
+			}
+			else {
+				entry.pn = kInfinitePnDn;
+				entry.dn = 0;
+				entry.minimum_distance = std::min(entry.minimum_distance, depth);
+			}
+			return;
+		case REPETITION_LOSE:
+		case REPETITION_DRAW:
+			if (or_node) {
+				entry.pn = kInfinitePnDn;
+				entry.dn = 0;
+				entry.minimum_distance = std::min(entry.minimum_distance, depth);
+			}
+			else {
+				// ここは通らないはず
+				entry.pn = 0;
+				entry.dn = kInfinitePnDn;
+				entry.minimum_distance = std::min(entry.minimum_distance, depth);
+			}
+			return;
+		}
+
 		MovePicker move_picker(n, or_node);
 		if (move_picker.empty()) {
 			// nが先端ノード

--- a/source/engine/mate-engine/mate-search.cpp
+++ b/source/engine/mate-engine/mate-search.cpp
@@ -253,36 +253,54 @@ namespace MateEngine
 			return;
 		}
 
-		auto draw_type = n.is_repetition(n.game_ply());
-		switch (draw_type) {
-		case REPETITION_WIN:
-			if (or_node) {
-				// ここは通らないはず
-				entry.pn = 0;
-				entry.dn = kInfinitePnDn;
-				entry.minimum_distance = std::min(entry.minimum_distance, depth);
-			}
-			else {
-				entry.pn = kInfinitePnDn;
-				entry.dn = 0;
-				entry.minimum_distance = std::min(entry.minimum_distance, depth);
-			}
-			return;
-		case REPETITION_LOSE:
-		case REPETITION_DRAW:
-			if (or_node) {
-				entry.pn = kInfinitePnDn;
-				entry.dn = 0;
-				entry.minimum_distance = std::min(entry.minimum_distance, depth);
-			}
-			else {
-				// ここは通らないはず
-				entry.pn = 0;
-				entry.dn = kInfinitePnDn;
-				entry.minimum_distance = std::min(entry.minimum_distance, depth);
-			}
-			return;
-		}
+    // 千日手のチェック
+    // 対局規定（抄録）｜よくある質問｜日本将棋連盟 https://www.shogi.or.jp/faq/taikyoku-kitei.html
+    // 第8条 反則
+    // 7. 連続王手の千日手とは、同一局面が４回出現した一連の手順中、片方の手が
+    // すべて王手だった場合を指し、王手を続けた側がその時点で負けとなる。
+    // 従って開始局面により、連続王手の千日手成立局面が王手をかけた状態と
+    // 王手を解除した状態の二つのケースがある。 （※）
+    // （※）は平成25年10月1日より暫定施行。
+    auto draw_type = n.is_repetition(n.game_ply());
+    switch (draw_type) {
+    case REPETITION_WIN:
+      // 連続王手の千日手による勝ち
+      if (or_node) {
+        // ここは通らないはず
+        entry.pn = 0;
+        entry.dn = kInfinitePnDn;
+        entry.minimum_distance = std::min(entry.minimum_distance, depth);
+      }
+      else {
+        entry.pn = kInfinitePnDn;
+        entry.dn = 0;
+        entry.minimum_distance = std::min(entry.minimum_distance, depth);
+      }
+      return;
+
+    case REPETITION_LOSE:
+      // 連続王手の千日手による負け
+      if (or_node) {
+        entry.pn = kInfinitePnDn;
+        entry.dn = 0;
+        entry.minimum_distance = std::min(entry.minimum_distance, depth);
+      }
+      else {
+        // ここは通らないはず
+        entry.pn = 0;
+        entry.dn = kInfinitePnDn;
+        entry.minimum_distance = std::min(entry.minimum_distance, depth);
+      }
+      return;
+
+    case REPETITION_DRAW:
+      // 普通の千日手
+      // ここは通らないはず
+      entry.pn = kInfinitePnDn;
+      entry.dn = 0;
+      entry.minimum_distance = std::min(entry.minimum_distance, depth);
+      return;
+    }
 
 		MovePicker move_picker(n, or_node);
 		if (move_picker.empty()) {

--- a/source/engine/mate-engine/mate-search.cpp
+++ b/source/engine/mate-engine/mate-search.cpp
@@ -253,54 +253,54 @@ namespace MateEngine
 			return;
 		}
 
-    // 千日手のチェック
-    // 対局規定（抄録）｜よくある質問｜日本将棋連盟 https://www.shogi.or.jp/faq/taikyoku-kitei.html
-    // 第8条 反則
-    // 7. 連続王手の千日手とは、同一局面が４回出現した一連の手順中、片方の手が
-    // すべて王手だった場合を指し、王手を続けた側がその時点で負けとなる。
-    // 従って開始局面により、連続王手の千日手成立局面が王手をかけた状態と
-    // 王手を解除した状態の二つのケースがある。 （※）
-    // （※）は平成25年10月1日より暫定施行。
-    auto draw_type = n.is_repetition(n.game_ply());
-    switch (draw_type) {
-    case REPETITION_WIN:
-      // 連続王手の千日手による勝ち
-      if (or_node) {
-        // ここは通らないはず
-        entry.pn = 0;
-        entry.dn = kInfinitePnDn;
-        entry.minimum_distance = std::min(entry.minimum_distance, depth);
-      }
-      else {
-        entry.pn = kInfinitePnDn;
-        entry.dn = 0;
-        entry.minimum_distance = std::min(entry.minimum_distance, depth);
-      }
-      return;
+		// 千日手のチェック
+		// 対局規定（抄録）｜よくある質問｜日本将棋連盟 https://www.shogi.or.jp/faq/taikyoku-kitei.html
+		// 第8条 反則
+		// 7. 連続王手の千日手とは、同一局面が４回出現した一連の手順中、片方の手が
+		// すべて王手だった場合を指し、王手を続けた側がその時点で負けとなる。
+		// 従って開始局面により、連続王手の千日手成立局面が王手をかけた状態と
+		// 王手を解除した状態の二つのケースがある。 （※）
+		// （※）は平成25年10月1日より暫定施行。
+		auto draw_type = n.is_repetition(n.game_ply());
+		switch (draw_type) {
+		case REPETITION_WIN:
+			// 連続王手の千日手による勝ち
+			if (or_node) {
+				// ここは通らないはず
+				entry.pn = 0;
+				entry.dn = kInfinitePnDn;
+				entry.minimum_distance = std::min(entry.minimum_distance, depth);
+			}
+			else {
+				entry.pn = kInfinitePnDn;
+				entry.dn = 0;
+				entry.minimum_distance = std::min(entry.minimum_distance, depth);
+			}
+			return;
 
-    case REPETITION_LOSE:
-      // 連続王手の千日手による負け
-      if (or_node) {
-        entry.pn = kInfinitePnDn;
-        entry.dn = 0;
-        entry.minimum_distance = std::min(entry.minimum_distance, depth);
-      }
-      else {
-        // ここは通らないはず
-        entry.pn = 0;
-        entry.dn = kInfinitePnDn;
-        entry.minimum_distance = std::min(entry.minimum_distance, depth);
-      }
-      return;
+		case REPETITION_LOSE:
+			// 連続王手の千日手による負け
+			if (or_node) {
+				entry.pn = kInfinitePnDn;
+				entry.dn = 0;
+				entry.minimum_distance = std::min(entry.minimum_distance, depth);
+			}
+			else {
+				// ここは通らないはず
+				entry.pn = 0;
+				entry.dn = kInfinitePnDn;
+				entry.minimum_distance = std::min(entry.minimum_distance, depth);
+			}
+			return;
 
-    case REPETITION_DRAW:
-      // 普通の千日手
-      // ここは通らないはず
-      entry.pn = kInfinitePnDn;
-      entry.dn = 0;
-      entry.minimum_distance = std::min(entry.minimum_distance, depth);
-      return;
-    }
+		case REPETITION_DRAW:
+			// 普通の千日手
+			// ここは通らないはず
+			entry.pn = kInfinitePnDn;
+			entry.dn = 0;
+			entry.minimum_distance = std::min(entry.minimum_distance, depth);
+			return;
+		}
 
 		MovePicker move_picker(n, or_node);
 		if (move_picker.empty()) {
@@ -508,7 +508,7 @@ namespace MateEngine
 
 	// 詰将棋探索のエントリポイント
 	void dfpn(Position& r) {
-        Threads.stop = false;
+		Threads.stop = false;
 
 		if (r.in_check()) {
 			// 逆王手からの詰みは対応しないので、notimplementedを返す.
@@ -546,7 +546,7 @@ namespace MateEngine
 			// pv サブコマンドは info コマンドの最後に書く。
 			std::ostringstream oss;
 			oss << "info depth " << moves.size() << " time " << time_ms << " nodes " << nodes_searched
-			    << " score mate + nps " << nps << " pv";
+				<< " score mate + nps " << nps << " pv";
 			for (const auto& move : moves) {
 				oss << " " << move;
 			}


### PR DESCRIPTION
千日手のチェックを追加しました。
これにより一部の問題で大幅に高速化しました。

floodgate blogリンク | floodgateリンク | sfen | floodgate blog予測手数 | 変更前 (ms) | 変更後 (ms)
-- | -- | -- | -- | -- | --
http://b.kifupedia.org/20170430.html#p29 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2Bukamuse_6700K%2Bcatshogi%2B20170430143005.csa&move_to=102 | sfen l2g5/2s3g2/3k1p2p/P2pp2P1/1pP4s1/p1+B6/NP1P+nPS1P/K1G4+p1/L6NL b RBGNLPrs3p 1 | 33 | 2976 | 2856
http://b.kifupedia.org/20170430.html#p18 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2Bcoduck_pi2_600MHz_1c%2BShogiNet%2B20170430110007.csa&move_to=100 | sfen 6lnk/6+Rbl/2n4pp/7s1/1p2P2NP/p1P2PPP1/1P4GS1/6GK1/LNr5L b B2G2S6Pp 1 | 27 | 1407 | 1378
http://b.kifupedia.org/20170430.html#p17 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2BSM_1_25_Xeon_E5_2698_v4_40c%2BSILENT_MAJORITY_1.25_6950X%2B20170430103005.csa&move_to=195 | sfen lnks5/1pg1s4/2p5p/p4+r3/P1g6/1Nn6/BKN1P3P/9/LG2s4 w GSL2Prbl9p 1 | 51 | 13928 | 16326
http://b.kifupedia.org/20170430.html#p16 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2Bcatshogi%2Bgps_l%2B20170430070003.csa&move_to=134 | sfen l7l/2+Rbk4/3rp4/2p3pPs/p2P1p2p/2P1G4/P1N1PPN2/2GK2G2/L7L b B2S6Pgs2n 1 | 39 | 1443 | 1507
http://b.kifupedia.org/20170430.html#p15 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2Bcatshogi%2BGikouAperyEvalMix_SeoTsume_i5-33%2B20170430063002.csa&move_to=127 | sfen l5g1l/2s+B5/p2ppp2p/5kpP1/3n5/6Pp1/P3PP1lP/2+nr2SS1/3N1GKRL w G2Pbgsn3p 1 | 33 | 1613 | 1862
http://b.kifupedia.org/20170430.html#p10 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2BGc_at_Cortex-A53_4c%2BSaturday_Crush_4770K%2B20170430023007.csa&move_to=99 | sfen l4g2l/7k1/p1+Pp3pp/5ss1P/3Pp1gP1/P3SL3/N2GPK3/1+rP6/+p6RL w BG2N2Pbsn3p 1 | 53 | 7871 | 8125
http://b.kifupedia.org/20170430.html#p09 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2BSM_1_25_Xeon_E5_2698_v4_40c%2Bukamuse_i7%2B20170430013007.csa&move_to=116 | sfen l2s3nl/3g1p+R+R1/p1k5p/2pPp4/1p1p5/5Sp2/PPP1PP2P/3G5/L1K4NL b BG2S2Pbg2np 1 | 47 | 143221 | 9407
http://b.kifupedia.org/20170430.html#p08 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2BGc_at_Cortex-A53_4c%2Bsonic%2B20170430013003.csa&move_to=149 | sfen ln7/2gk1S+S2/2+rpPp2G/2p5p/PP4P2/3B4P/K1SP3PN/1Sg2P+np1/L+r6L w L2Pbgn3p 1 | 45 | 13854 | 10073
http://b.kifupedia.org/20170430.html#p07 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2BTest_NB10.5_i5_6200U%2BGikouAperyEvalMix_SeoTsume_i5-33%2B20170430010007.csa&move_to=121 | sfen 6p1l/1+R1G2g2/5pns1/pp1pk3p/2p3P2/P7P/1L1PSP+b2/1SG1K2P1/L5G1L w N2Prbs2n3p 1 | 27 | 3837 | 4375
http://b.kifupedia.org/20170430.html#p06 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2BInoue%2Byeu%2B20170430003006.csa&move_to=144 | sfen lng3+R2/2kgs4/ppp6/1B1pp4/7B1/2P2pLp1/PP1PP3P/1S1K2p2/LN5GL b RG2SP2n3p 1 | 39 | 798 | 774

