### PR TITLE
詰み手順を復元する探索ルーチンの中で受け手側の手番かつ王手がかかっている状況で1手詰みルーチンを呼び出すバグを修正した

### DIFF
--- a/source/engine/mate-engine/mate-search.cpp
+++ b/source/engine/mate-engine/mate-search.cpp
@@ -548,7 +548,7 @@ namespace MateEngine
 		auto& mate_state = memo[key];
 
 		auto mate1ply = pos.mate1ply();
-		if (mate1ply) {
+		if (or_node && !pos.in_check() && mate1ply) {
 			mate_state.num_moves_to_mate = 1;
 			mate_state.move_to_mate = mate1ply;
 


### PR DESCRIPTION
詰手順を復元する探索ルーチンの中で
受け手側の手番かつ王手がかかっている状況で
1手詰みルーチンを呼び出しているバグを修正しました。
これにより金子清志氏の全応手逆王手最長１５手で
合法な詰手順が出力されるようになりました。
http://www.ne.jp/asahi/tetsu/toybox/challenge/c1090.htm
ただし、最短の詰手順ではありません。