### PR TITLE
ハッシュエントリをつぶすとき、探索ノード数を考慮するようにした

### DIFF
--- a/source/engine/mate-engine/mate-search.cpp
+++ b/source/engine/mate-engine/mate-search.cpp
@@ -147,10 +147,14 @@ namespace MateEngine
 				}
 			}
 
-			// 合致するエントリが見つからなかったので
+			// 合致するエントリが見つからなかったので古いエントリをつぶす
+			// 優先度は
+			// - 世代が一番古いもの
+			// - 探索ノード数が小さいもの
 			// 世代が一番古いエントリをつぶす
 			TTEntry* best_entry = nullptr;
 			uint32_t best_generation = UINT_MAX;
+			int best_num_searched = INT_MAX;
 			for (auto& entry : entries.entries) {
 				uint32_t temp_generation;
 				if (generation < entry.generation) {
@@ -160,9 +164,11 @@ namespace MateEngine
 					temp_generation = generation - entry.generation;
 				}
 
-				if (best_generation > temp_generation) {
+				if (best_generation > temp_generation ||
+					(best_generation == temp_generation && best_num_searched > entry.num_searched)) {
 					best_entry = &entry;
 					best_generation = temp_generation;
+					best_num_searched = entry.num_searched;
 				}
 			}
 			best_entry->hash_high = hash_high;


### PR DESCRIPTION
置換表のハッシュエントリをつぶすとき、探索ノード数の小さいものを優先的につぶすよう変更しました。
これにより若干回答速度が上がりました。


floodgate blogリンク | floodgateリンク | sfen | floodgate blog予測手数 | 変更前 | 変更後
-- | -- | -- | -- | -- | --
http://b.kifupedia.org/20170430.html#p29 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2Bukamuse_6700K%2Bcatshogi%2B20170430143005.csa&move_to=102 | sfen l2g5/2s3g2/3k1p2p/P2pp2P1/1pP4s1/p1+B6/NP1P+nPS1P/K1G4+p1/L6NL b RBGNLPrs3p 1 | 33 | 2808 | 2576
http://b.kifupedia.org/20170430.html#p18 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2Bcoduck_pi2_600MHz_1c%2BShogiNet%2B20170430110007.csa&move_to=100 | sfen 6lnk/6+Rbl/2n4pp/7s1/1p2P2NP/p1P2PPP1/1P4GS1/6GK1/LNr5L b B2G2S6Pp 1 | 27 | 1348 | 1354
http://b.kifupedia.org/20170430.html#p17 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2BSM_1_25_Xeon_E5_2698_v4_40c%2BSILENT_MAJORITY_1.25_6950X%2B20170430103005.csa&move_to=195 | sfen lnks5/1pg1s4/2p5p/p4+r3/P1g6/1Nn6/BKN1P3P/9/LG2s4 w GSL2Prbl9p 1 | 51 | 16024 | 14608
http://b.kifupedia.org/20170430.html#p16 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2Bcatshogi%2Bgps_l%2B20170430070003.csa&move_to=134 | sfen l7l/2+Rbk4/3rp4/2p3pPs/p2P1p2p/2P1G4/P1N1PPN2/2GK2G2/L7L b B2S6Pgs2n 1 | 39 | 1582 | 1576
http://b.kifupedia.org/20170430.html#p15 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2Bcatshogi%2BGikouAperyEvalMix_SeoTsume_i5-33%2B20170430063002.csa&move_to=127 | sfen l5g1l/2s+B5/p2ppp2p/5kpP1/3n5/6Pp1/P3PP1lP/2+nr2SS1/3N1GKRL w G2Pbgsn3p 1 | 33 | 1856 | 1495
http://b.kifupedia.org/20170430.html#p10 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2BGc_at_Cortex-A53_4c%2BSaturday_Crush_4770K%2B20170430023007.csa&move_to=99 | sfen l4g2l/7k1/p1+Pp3pp/5ss1P/3Pp1gP1/P3SL3/N2GPK3/1+rP6/+p6RL w BG2N2Pbsn3p 1 | 53 | 7930 | 7508
http://b.kifupedia.org/20170430.html#p09 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2BSM_1_25_Xeon_E5_2698_v4_40c%2Bukamuse_i7%2B20170430013007.csa&move_to=116 | sfen l2s3nl/3g1p+R+R1/p1k5p/2pPp4/1p1p5/5Sp2/PPP1PP2P/3G5/L1K4NL b BG2S2Pbg2np 1 | 47 | 9133 | 8740
http://b.kifupedia.org/20170430.html#p08 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2BGc_at_Cortex-A53_4c%2Bsonic%2B20170430013003.csa&move_to=149 | sfen ln7/2gk1S+S2/2+rpPp2G/2p5p/PP4P2/3B4P/K1SP3PN/1Sg2P+np1/L+r6L w L2Pbgn3p 1 | 45 | 9647 | 8738
http://b.kifupedia.org/20170430.html#p07 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2BTest_NB10.5_i5_6200U%2BGikouAperyEvalMix_SeoTsume_i5-33%2B20170430010007.csa&move_to=121 | sfen 6p1l/1+R1G2g2/5pns1/pp1pk3p/2p3P2/P7P/1L1PSP+b2/1SG1K2P1/L5G1L w N2Prbs2n3p 1 | 27 | 4170 | 4232
http://b.kifupedia.org/20170430.html#p06 | http://wdoor.c.u-tokyo.ac.jp/shogi/view/index.cgi?csa=http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/2017/04/30/wdoor%2Bfloodgate-300-10F%2BInoue%2Byeu%2B20170430003006.csa&move_to=144 | sfen lng3+R2/2kgs4/ppp6/1B1pp4/7B1/2P2pLp1/PP1PP3P/1S1K2p2/LN5GL b RG2SP2n3p 1 | 39 | 759 | 756

よろしくお願いいたします。
