### PR TITLE
詰将棋ルーチンで受け側の局面から探索させたあとに攻め側の局面から探索させると不詰と出力されるバグを修正した

### DIFF
--- a/source/engine/mate-engine/mate-search.cpp
+++ b/source/engine/mate-engine/mate-search.cpp
@@ -129,7 +129,7 @@ namespace MateEngine
 			uint32_t hash_high = key >> 32;
 			// 検索条件に合致するエントリを返す
 			for (auto& entry : entries.entries) {
-				if (entry.hash_high == 0) {
+				if (entry.hash_high == 0 || entry.generation != generation) {
 					// 空のエントリが見つかった場合
 					entry.hash_high = hash_high;
 					entry.pn = 1;
@@ -149,25 +149,13 @@ namespace MateEngine
 
 			// 合致するエントリが見つからなかったので古いエントリをつぶす
 			// 優先度は
-			// - 世代が一番古いもの
 			// - 探索ノード数が小さいもの
 			// 世代が一番古いエントリをつぶす
 			TTEntry* best_entry = nullptr;
-			uint32_t best_generation = UINT_MAX;
 			int best_num_searched = INT_MAX;
 			for (auto& entry : entries.entries) {
-				uint32_t temp_generation;
-				if (generation < entry.generation) {
-					temp_generation = 256 - entry.generation + generation;
-				}
-				else {
-					temp_generation = generation - entry.generation;
-				}
-
-				if (best_generation > temp_generation ||
-					(best_generation == temp_generation && best_num_searched > entry.num_searched)) {
+				if (best_num_searched > entry.num_searched) {
 					best_entry = &entry;
-					best_generation = temp_generation;
 					best_num_searched = entry.num_searched;
 				}
 			}


### PR DESCRIPTION
異なる世代のキャッシュエントリを使用しないようにし、受け側の局面から探索させたあとに攻め側の局面から探索させると不詰と出力されるバグを修正しました。

よろしくお願いいたします。
