### PR TITLE
Makefiles

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -30,38 +30,65 @@ ARCH_DEF := -DTARGET_ARCH="$(TARGET_ARCH_ABI)"
 # example: 2018 Otafuku (EVAL_MATERIAL)
 # $ ndk-build ENGINE_TARGET=YANEURAOU_2018_OTAFUKU_ENGINE_MATERIAL
 
-# example: 2018 T.N.K. (EVAL_NNUE)
+# example: 2018 T.N.K. (EVAL_NNUE_HALFKP_256x2_32_32)
 # $ ndk-build ENGINE_TARGET=YANEURAOU_2018_TNK_ENGINE
+
+# example: 2018 T.N.K. (EVAL_NNUE_HALFKP_256x2_32_32)
+# $ ndk-build ENGINE_TARGET=YANEURAOU_2018_TNK_ENGINE_HALFKP
+
+# example: 2018 T.N.K. (EVAL_NNUE_K_P_256x2_32_32)
+# $ ndk-build ENGINE_TARGET=YANEURAOU_2018_TNK_ENGINE_K_P
+
+# example: tnk- Mate (MATE_ENGINE)
+# $ ndk-build ENGINE_TARGET=MATE_ENGINE
 
 ENGINE_TARGET := YANEURAOU_2018_OTAFUKU_ENGINE
 #ENGINE_TARGET := YANEURAOU_2018_OTAFUKU_ENGINE_KPPT
 #ENGINE_TARGET := YANEURAOU_2018_OTAFUKU_ENGINE_KPP_KKPT
 #ENGINE_TARGET := YANEURAOU_2018_OTAFUKU_ENGINE_MATERIAL
 #ENGINE_TARGET := YANEURAOU_2018_TNK_ENGINE
+#ENGINE_TARGET := YANEURAOU_2018_TNK_ENGINE_HALFKP
+#ENGINE_TARGET := YANEURAOU_2018_TNK_ENGINE_K_P
+#ENGINE_TARGET := MATE_ENGINE
 
 ifeq ($(ENGINE_TARGET),YANEURAOU_2018_OTAFUKU_ENGINE)
   ARCH_DEF += -DUSE_MAKEFILE -DYANEURAOU_2018_OTAFUKU_ENGINE
-  ENGINE_NAME := YaneuraOu2018otafuku
+  ENGINE_NAME := YaneuraOu-otafuku
 endif
 
 ifeq ($(ENGINE_TARGET),YANEURAOU_2018_OTAFUKU_ENGINE_KPPT)
   ARCH_DEF += -DUSE_MAKEFILE -DYANEURAOU_2018_OTAFUKU_ENGINE
-  ENGINE_NAME := YaneuraOu2018otafuku-kppt
+  ENGINE_NAME := YaneuraOu-otafuku-kppt
 endif
 
 ifeq ($(ENGINE_TARGET),YANEURAOU_2018_OTAFUKU_ENGINE_KPP_KKPT)
   ARCH_DEF += -DUSE_MAKEFILE -DYANEURAOU_2018_OTAFUKU_ENGINE_KPP_KKPT
-  ENGINE_NAME := YaneuraOu2018otafuku-kpp_kkpt
+  ENGINE_NAME := YaneuraOu-otafuku-kpp_kkpt
 endif
 
 ifeq ($(ENGINE_TARGET),YANEURAOU_2018_OTAFUKU_ENGINE_MATERIAL)
   ARCH_DEF += -DUSE_MAKEFILE -DYANEURAOU_2018_OTAFUKU_ENGINE_MATERIAL
-  ENGINE_NAME := YaneuraOu2018otafuku-material
+  ENGINE_NAME := YaneuraOu-otafuku-material
 endif
 
 ifeq ($(ENGINE_TARGET),YANEURAOU_2018_TNK_ENGINE)
   ARCH_DEF += -DUSE_MAKEFILE -DYANEURAOU_2018_TNK_ENGINE
-  ENGINE_NAME := YaneuraOu2018tnk
+  ENGINE_NAME := YaneuraOu-tnk
+endif
+
+ifeq ($(ENGINE_TARGET),YANEURAOU_2018_TNK_ENGINE_HALFKP)
+  ARCH_DEF += -DUSE_MAKEFILE -DYANEURAOU_2018_TNK_ENGINE_HALFKP
+  ENGINE_NAME := YaneuraOu-tnk-half_kp
+endif
+
+ifeq ($(ENGINE_TARGET),YANEURAOU_2018_TNK_ENGINE_K_P)
+  ARCH_DEF += -DUSE_MAKEFILE -DYANEURAOU_2018_TNK_ENGINE_K_P
+  ENGINE_NAME := YaneuraOu-tnk-k_p
+endif
+
+ifeq ($(ENGINE_TARGET),MATE_ENGINE)
+  ARCH_DEF += -DUSE_MAKEFILE -DMATE_ENGINE
+  ENGINE_NAME := YaneuraOu-tnk-mate
 endif
 
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
@@ -74,7 +101,7 @@ ifeq ($(TARGET_ARCH_ABI),x86_64)
 endif
 
 ifeq ($(TARGET_ARCH_ABI),x86)
-  ARCH_DEF += 
+  ARCH_DEF +=
 endif
 
 ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
@@ -86,23 +113,27 @@ LOCAL_MODULE    := $(ENGINE_NAME)-$(TARGET_ARCH_ABI)
 LOCAL_CXXFLAGS  := -std=c++14 -fno-exceptions -fno-rtti -Wextra -Ofast -MMD -MP -fpermissive -D__STDINT_MACROS -D__STDC_LIMIT_MACROS $(ARCH_DEF)
 LOCAL_CXXFLAGS += -fPIE -Wno-unused-parameter
 LOCAL_LDFLAGS += -fPIE -pie -flto
-LOCAL_LDLIBS = 
-LOCAL_C_INCLUDES := 
+LOCAL_LDLIBS =
+LOCAL_C_INCLUDES :=
 LOCAL_CPP_FEATURES += exceptions rtti
 #LOCAL_STATIC_LIBRARIES    := -lpthread
 
 LOCAL_SRC_FILES := \
-  ../source/shogi.cpp                                                  \
+  ../source/main.cpp                                                   \
+  ../source/types.cpp                                                  \
   ../source/bitboard.cpp                                               \
   ../source/misc.cpp                                                   \
   ../source/movegen.cpp                                                \
   ../source/position.cpp                                               \
   ../source/usi.cpp                                                    \
+  ../source/usi_option.cpp                                             \
   ../source/thread.cpp                                                 \
   ../source/tt.cpp                                                     \
-  ../source/move_picker.cpp                                            \
+  ../source/movepick.cpp                                               \
+  ../source/timeman.cpp                                                \
   ../source/extra/book/apery_book.cpp                                  \
   ../source/extra/book/book.cpp                                        \
+  ../source/extra/book/makebook2019.cpp                                \
   ../source/extra/bitop.cpp                                            \
   ../source/extra/entering_king_win.cpp                                \
   ../source/extra/long_effect.cpp                                      \
@@ -111,7 +142,6 @@ LOCAL_SRC_FILES := \
   ../source/extra/mate/mate_n_ply.cpp                                  \
   ../source/extra/benchmark.cpp                                        \
   ../source/extra/test_cmd.cpp                                         \
-  ../source/extra/timeman.cpp                                          \
   ../source/extra/see.cpp                                              \
   ../source/extra/sfen_packer.cpp                                      \
   ../source/extra/kif_converter/kif_convert_tools.cpp                  \
@@ -120,27 +150,21 @@ LOCAL_SRC_FILES := \
   ../source/eval/kppt/evaluate_kppt_learner.cpp                        \
   ../source/eval/kpp_kkpt/evaluate_kpp_kkpt.cpp                        \
   ../source/eval/kpp_kkpt/evaluate_kpp_kkpt_learner.cpp                \
-  ../source/eval/kpppt/evaluate_kpppt.cpp                              \
-  ../source/eval/kpppt/evaluate_kpppt_learner.cpp                      \
-  ../source/eval/kppp_kkpt/evaluate_kppp_kkpt.cpp                      \
-  ../source/eval/kppp_kkpt/evaluate_kppp_kkpt_learner.cpp              \
-  ../source/eval/kkpp_kkpt/evaluate_kkpp_kkpt.cpp                      \
-  ../source/eval/kkpp_kkpt/evaluate_kkpp_kkpt_learner.cpp              \
-  ../source/eval/kkppt/evaluate_kkppt.cpp                              \
-  ../source/eval/kkppt/evaluate_kkppt_learner.cpp                      \
-  ../source/eval/kpp_kkpt_fv_var/evaluate_kpp_kkpt_fv_var.cpp          \
-  ../source/eval/kpp_kkpt_fv_var/evaluate_kpp_kkpt_fv_var_learner.cpp  \
   ../source/eval/evaluate.cpp                                          \
   ../source/eval/evaluate_io.cpp                                       \
   ../source/eval/evaluate_mir_inv_tools.cpp                            \
   ../source/engine/user-engine/user-search.cpp                         \
-  ../source/engine/help-mate-engine/help-mate-search.cpp               \
   ../source/engine/2018-otafuku-engine/2018-otafuku-search.cpp         \
   ../source/learn/learner.cpp                                          \
   ../source/learn/learning_tools.cpp                                   \
   ../source/learn/multi_think.cpp
 
-ifeq ($(ENGINE_TARGET),YANEURAOU_2018_TNK_ENGINE)
+ifeq ($(ENGINE_TARGET),MATE_ENGINE)
+LOCAL_SRC_FILES += \
+	../source/engine/mate-engine/mate-search.cpp
+endif
+
+ifeq ($(findstring YANEURAOU_2018_TNK_ENGINE,$(ENGINE_TARGET)),YANEURAOU_2018_TNK_ENGINE)
 LOCAL_SRC_FILES += \
   ../source/eval/nnue/evaluate_nnue.cpp                                \
   ../source/eval/nnue/evaluate_nnue_learner.cpp                        \

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,4 +1,3 @@
-#APP_ABI := x86 armeabi-v7a
-APP_ABI := arm64-v8a x86_64
-APP_STL:=c++_static
-APP_PLATFORM = android-16
+APP_ABI := arm64-v8a x86_64 armeabi-v7a x86
+APP_STL := c++_static
+APP_PLATFORM = android-19

--- a/source/Makefile
+++ b/source/Makefile
@@ -33,7 +33,12 @@ ifeq ($(findstring clang++,$(COMPILER)),clang++)
 	WCFLAGS += -fno-threadsafe-statics
 
 	# msys2用のclangでは、OpenMP使えない？インスコ仕方がわからん。
-
+else
+	ifeq ($(findstring g++,$(COMPILER)),g++)
+		# https://stackoverflow.com/questions/43152633/invalid-register-for-seh-savexmm-in-cygwin
+		# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782
+		WCFLAGS += -fno-asynchronous-unwind-tables
+	endif
 endif
 
 ifeq ($(OS),Windows_NT)
@@ -84,9 +89,23 @@ ifeq ($(findstring g++,$(COMPILER)),g++)
 	endif
 endif
 ifeq ($(findstring clang++,$(COMPILER)),clang++)
-	OPENMP   = -fopenmp
+	ifeq ($(MSYSTEM),MINGW64)
+		# MSYS2 MINGW64 env
+		# libgompを指定した場合、ビルドは通るがOpenMPは無効化される？
+		OPENMP = -fopenmp=libgomp
+		OPENMP_LDFLAGS =
+	else
+		ifeq ($(findstring w64-mingw32,$(COMPILER)),w64-mingw32)
+			# Ubuntu mingw-w64 clang++ env (experimental)
+			OPENMP = -fopenmp=libgomp
+			OPENMP_LDFLAGS =
+		else
+			# Other (normal clang++/libomp env)
+			OPENMP = -fopenmp
 	OPENMP_LDFLAGS = -lomp
-	ifeq ($(YANEURAOU_EDITION),YANEURAOU_2018_TNK_ENGINE)
+		endif
+	endif
+	ifeq ($(findstring YANEURAOU_2018_TNK_ENGINE,$(YANEURAOU_EDITION)),YANEURAOU_2018_TNK_ENGINE)
 		BLAS = -DUSE_BLAS
 		BLAS_LDFLAGS = -lopenblas
 		ifeq ($(MSYSTEM),MINGW64)
@@ -148,7 +167,7 @@ ifeq ($(YANEURAOU_EDITION),MATE_ENGINE)
 	SOURCES += engine/mate-engine/mate-search.cpp
 endif
 
-ifeq ($(YANEURAOU_EDITION),YANEURAOU_2018_TNK_ENGINE)
+ifeq ($(findstring YANEURAOU_2018_TNK_ENGINE,$(YANEURAOU_EDITION)),YANEURAOU_2018_TNK_ENGINE)
 	SOURCES += eval/nnue/evaluate_nnue.cpp                                     \
 	           eval/nnue/evaluate_nnue_learner.cpp                             \
 	           eval/nnue/nnue_test_command.cpp                                 \
@@ -170,30 +189,49 @@ $(OBJDIR)/%.o: %.cpp
 
 all: clean $(TARGET)
 
+# https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
+
 # 学習用バイナリのときは、openmpを有効にする。
-evallearn:
+evallearn-icelake:
+	$(MAKE) CFLAGS='$(CFLAGS) $(OPENMP) $(BLAS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_AVX512 -DUSE_AVX512VLBWDQ -DUSE_AVX512VNNI -march=icelake-client' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
+evallearn-cascadelake:
+	$(MAKE) CFLAGS='$(CFLAGS) $(OPENMP) $(BLAS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_AVX512 -DUSE_AVX512VLBWDQ -DUSE_AVX512VNNI -march=cascadelake' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
+evallearn-avx512:
+	$(MAKE) CFLAGS='$(CFLAGS) $(OPENMP) $(BLAS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_AVX512 -DUSE_AVX512VLBWDQ -march=skylake-avx512' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
+evallearn-avx2:
 	$(MAKE) CFLAGS='$(CFLAGS) $(OPENMP) $(BLAS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_AVX2 -mbmi -mbmi2 -mavx2 -march=corei7-avx' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
 evallearn-sse42:
 	$(MAKE) CFLAGS='$(CFLAGS) $(OPENMP) $(BLAS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_SSE42 -msse4.2 -march=corei7' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
+evallearn: evallearn-avx2
 
 # 教師棋譜生成用
 gensfen:
 	$(MAKE) CFLAGS='$(CFLAGS) $(OPENMP) $(BLAS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_AVX2 -mbmi -mbmi2 -mavx2 -DGENSFEN2019 -march=corei7-avx' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
 
-tournament:
+tournament-icelake:
+	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_AVX512 -DUSE_AVX512VLBWDQ -DUSE_AVX512VNNI -DFOR_TOURNAMENT -march=icelake-client' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
+tournament-cascadelake:
+	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_AVX512 -DUSE_AVX512VLBWDQ -DUSE_AVX512VNNI -DFOR_TOURNAMENT -march=cascadelake' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
+tournament-avx512:
+	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_AVX512 -DUSE_AVX512VLBWDQ -DFOR_TOURNAMENT -march=skylake-avx512' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
+tournament-avx2:
 	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_AVX2 -mbmi -mbmi2 -mavx2 -DFOR_TOURNAMENT -march=corei7-avx' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
 tournament-sse42:
 	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_SSE42 -msse4.2 -DFOR_TOURNAMENT -march=corei7' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
+tournament: tournament-avx2
 
+icelake:
+	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_AVX512 -DUSE_AVX512VLBWDQ -DUSE_AVX512VNNI -march=icelake-client' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
+cascadelake:
+	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_AVX512 -DUSE_AVX512VLBWDQ -DUSE_AVX512VNNI -march=cascadelake' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
+avx512:
+	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_AVX512 -DUSE_AVX512VLBWDQ -march=skylake-avx512' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
 avx2:
 	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_AVX2 -mbmi -mbmi2 -mavx2 -march=corei7-avx' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
-
 sse42:
 	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_SSE42 -msse4.2 -march=corei7' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
-
 sse41:
 	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_SSE41 -msse4.1 -march=core2' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
-
 sse2:
 	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DUSE_MAKEFILE -D$(YANEURAOU_EDITION) -DUSE_SSE2 -msse2 -march=core2' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
 

--- a/source/config.h
+++ b/source/config.h
@@ -314,9 +314,15 @@
 #endif
 
 // NNUE評価関数を積んだtanuki-エンジン
-#if defined(YANEURAOU_2018_TNK_ENGINE)
+#if defined(YANEURAOU_2018_TNK_ENGINE) || defined(YANEURAOU_2018_TNK_ENGINE_HALFKP) || defined(YANEURAOU_2018_TNK_ENGINE_K_P)
 #define ENGINE_NAME "YaneuraOu 2018 T.N.K."
 #define EVAL_NNUE
+#if defined(YANEURAOU_2018_TNK_ENGINE_HALFKP)
+#define EVAL_NNUE_HALFKP_256x2_32_32
+#endif
+#if defined(YANEURAOU_2018_TNK_ENGINE_K_P)
+#define EVAL_NNUE_K_P_256x2_32_32
+#endif
 
 #define USE_EVAL_HASH
 #define USE_SEE
@@ -479,7 +485,7 @@ extern GlobalOptions_ GlobalOptions;
 #elif defined(__GNUC__)
 #define ALIGNED(X) __attribute__ ((aligned(X)))
 #else
-#define ALIGNED(X) 
+#define ALIGNED(X)
 #endif
 
 // --- output for Japanese notation

--- a/source/eval/nnue/nnue_architecture.h
+++ b/source/eval/nnue/nnue_architecture.h
@@ -8,8 +8,13 @@
 #if defined(EVAL_NNUE)
 
 // 入力特徴量とネットワーク構造が定義されたヘッダをincludeする
+#if defined(EVAL_NNUE_HALFKP_256x2_32_32)
 #include "architectures/halfkp_256x2-32-32.h"
-//#include "architectures/k-p_256x2-32-32.h"
+#elif defined(EVAL_NNUE_K_P_256x2_32_32)
+#include "architectures/k-p_256x2-32-32.h"
+#else
+#include "architectures/halfkp_256x2-32-32.h"
+#endif
 
 namespace Eval {
 

--- a/source/extra/bitop.h
+++ b/source/extra/bitop.h
@@ -15,21 +15,14 @@
 //   include intrinsic header
 // ----------------------------
 
-#if defined(USE_AVX512)
-#include <zmmintrin.h>
-#elif defined(USE_AVX2)
-#include <immintrin.h>
-#elif defined(USE_SSE42)
-#include <nmmintrin.h>
-#elif defined(USE_SSE41)
-#include <smmintrin.h>
-#elif defined(USE_SSE2)
-#include <emmintrin.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
 #elif defined(IS_ARM)
 #include <arm_neon.h>
 #include <mm_malloc.h> // for _mm_alloc()
 #else
-#if defined (__GNUC__) 
+#include <x86intrin.h>
+#if defined(__GNUC__)
 #include <mm_malloc.h> // for _mm_alloc()
 #endif
 #endif


### PR DESCRIPTION
- Android 向けビルドの最新コードへの追随。
- `EVAL_NNUE_HALFKP_256x2_32_32` と `EVAL_NNUE_K_P_256x2_32_32` を分けてビルドできるよう、 EDITION を追加。
- `AVX512VNNI` 等に後々対応しやすいよう、 intrinsic の整理、ビルドターゲットの追加。
- `MSYS2`,`MINGW64` 環境 `clang++` コンパイラで学習用バイナリをビルドする際の `OpenMP` 仮対応。