### PR TITLE
- fix `makebook endless_extend_tree`

### DIFF
--- a/source/extra/book/makebook2019.cpp
+++ b/source/extra/book/makebook2019.cpp
@@ -787,7 +787,7 @@ namespace {
 
 		for (int i = 0; i < iteration; ++i)
 		{
-			cout << "makebook engless_extend_tree : iteration " << i << endl;
+			cout << "makebook endless_extend_tree : iteration " << i << endl;
 
 			string command;
 #if 0
@@ -820,8 +820,7 @@ namespace {
 				// なので、やらない(´ω｀)
 
 				command = "think " + think_sfen_name + " " + read_book_name + " depth " + to_string(depth)
-					+ " startmoves " + to_string(start_moves) + " moves " + to_string(end_moves) + +" nodes " + to_string(nodes)
-					+ " max_game_ply " + to_string(max_game_ply);
+					+ " startmoves " + to_string(start_moves) + " moves " + to_string(end_moves) + " nodes " + to_string(nodes);
 				do_command(command);
 
 			}


### PR DESCRIPTION
`makebook think` コマンドでは `max_game_ply` なんてトークンは使えないよ、とエラーが出て `makebook endless_extend_tree` コマンドを正常に実行できない問題の修正です。