### PR TITLE
- `go perft <depth>` の探索修正

### DIFF
--- a/source/engine/yaneuraou-engine/yaneuraou-search.cpp
+++ b/source/engine/yaneuraou-engine/yaneuraou-search.cpp
@@ -1,4 +1,4 @@
-﻿#include "../../types.h"
+#include "../../types.h"
 
 #if defined (YANEURAOU_ENGINE)
 
@@ -267,7 +267,7 @@ namespace {
 		uint64_t cnt, nodes = 0;
 		const bool leaf = (depth == 2 * ONE_PLY);
 
-		for (const auto& m : MoveList<LEGAL>(pos))
+		for (const auto& m : MoveList<LEGAL_ALL>(pos))
 		{
 			if (Root && depth <= ONE_PLY)
 				cnt = 1, nodes++;


### PR DESCRIPTION
参考: https://qiita.com/ak11/items/8bd5f2bb0f5b014143c8

go perft 4 あたりからノード数が一致しない問題。

そもそも、一部 LEGAL_ALL で指し手生成されてませんでした…。