### PR TITLE
update mate-engine

### DIFF
--- a/source/search.h
+++ b/source/search.h
@@ -162,6 +162,9 @@ namespace Search {
 		// 全合法手を生成するのか
 		bool generate_all_legal_moves;
 #endif
+#if defined(MATE_ENGINE)
+		std::vector<Move> pv_check;
+#endif
 	};
 
 	extern LimitsType Limits;

--- a/source/usi.cpp
+++ b/source/usi.cpp
@@ -527,6 +527,15 @@ void go_cmd(const Position& pos, istringstream& is , StateListPtr& states) {
 			else
 				// USIプロトコルでは、UCIと異なり、ここは手数ではなく、探索に使う時間[ms]が指定されている。
 				limits.mate = stoi(token);
+			
+		}else if (token == "matedebug") {
+		  string token="";
+		  Move m;
+		  limits.pv_check.clear();
+		  while (is >> token && (m = USI::to_move(token)) != MOVE_NONE){
+		    limits.pv_check.push_back(m);
+		  }
+		 
 		}
 
 		// パフォーマンステスト(Stockfishにある、合法手N手で到達できる局面を求めるやつ)


### PR DESCRIPTION
詰将棋エンジンのアップデートを行いました。
- 千日手周りのbugfixを行い、詰む局面を不詰と判断する問題の一部を解決しました（おそらく全部解消できているわけではない）
- `go matedebug` というコマンドを作りました。具体的には以下のような使い方をします

詳しくは以下のページをご覧ください
- http://qhapaq.hatenablog.com/entry/2020/07/26/190856 （今回のプルリクについて）
- http://qhapaq.hatenablog.com/entry/2020/07/19/233054 (df-pnに関する解説)

````
position *** // 何らかの局面を与える
go mate 20000 // 詰み、不詰みを判断する
go matedebug 1e2e 1f2e 7g9e 8e7f // 開始局面から1e2d 1f2e...と読み進めた局面の詰み、不詰を出力する
````

matedebugを使うことで、詰将棋の特定の変化に対する解析を効率的に行うことが出来ます。出力は以下のようになっています。

````
pn,dn = 0,100000000
key-gen = 3903130028
 口^歩 金 口 口 口 口 口 口
 金^銀 と 口 口 口 口 口 口
^歩 歩 口 口 口 口 口 口 口
^桂 口^香^銀 銀 口 口 口 口
 馬 口 口 口 口 口 口^角 口
^桂 口^玉 口 口 口 口 口 口
 口 桂 口^歩 口 口 口 口 口
 口 銀 口 口 口 口 口 口 口
 口 口 口 口 口 口 口 口 口
先手 手駒 :  歩 飛 , 後手 手駒 :  歩12 香3 桂 飛 金2
手番 = 先手
sfen 1pG6/Gs+P6/pP7/n1lsS4/+B6b1/n1k6/1N1p5/1S7/9 b RPr2gn3l12p 5

pn,dn = 0,100000000
key-gen = 2430179078
example of mate moves : 9e7g(0) R*2f(0) //詰む場合は詰む手の一例が表示される。
 口^歩 金 口 口 口 口 口 口
 金^銀 と 口 口 口 口 口 口
^歩 歩 口 口 口 口 口 口 口
^桂 口^香^銀 銀 口 口 口 口
 馬 口 口 口 口 口 口^角 口
^桂 口^玉 口 口 口 口 飛 口
 口 桂 口^歩 口 口 口 口 口
 口 銀 口 口 口 口 口 口 口
 口 口 口 口 口 口 口 口 口
先手 手駒 :  歩 , 後手 手駒 :  歩12 香3 桂 飛 金2
手番 = 後手
sfen 1pG6/Gs+P6/pP7/n1lsS4/+B6b1/n1k4R1/1N1p5/1S7/9 w Pr2gn3l12p 6
````