### PR TITLE
- ユーザーの思考エンジンのコンパイルが通るように修正

### DIFF
--- a/source/config.h
+++ b/source/config.h
@@ -363,7 +363,8 @@
 
 #if defined(USER_ENGINE)
 #define ENGINE_NAME "YaneuraOu user engine"
-#define EVAL_KPP
+#define USE_SEE
+#define EVAL_MATERIAL
 #endif
 
 // --------------------


### PR DESCRIPTION
ユーザーの思考エンジンがデフォルトの状態だとコンパイルできませんでした。
とりあえずEVAL_MATERIALにしておきました。