### PR TITLE
Dev/20201106/pr cibuild

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -71,11 +71,20 @@ ifeq ($(findstring YANEURAOU_ENGINE_NNUE,$(ENGINE_TARGET)),YANEURAOU_ENGINE_NNUE
   ENGINE_NAME := YaneuraOu_NNUE
   ifeq ($(ENGINE_TARGET),YANEURAOU_ENGINE_NNUE_KP256)
     ENGINE_NAME := YaneuraOu_NNUE_KP256
-    CPPFLAGS += -DEVAL_NNUE_KP256
+    ARCH_DEF += -DEVAL_NNUE_KP256
   else
     ifeq ($(NNUE_EVAL_ARCH),KP256)
       ENGINE_NAME := YaneuraOu_NNUE_KP256
-      CPPFLAGS += -DEVAL_NNUE_KP256
+      ARCH_DEF += -DEVAL_NNUE_KP256
+    endif
+  endif
+  ifeq ($(ENGINE_TARGET),YANEURAOU_ENGINE_NNUE_HALFKPE9)
+    ENGINE_NAME := YaneuraOu_NNUE_HALFKPE9
+    ARCH_DEF += -DEVAL_NNUE_HALFKPE9
+  else
+    ifeq ($(NNUE_EVAL_ARCH),HALFKPE9)
+      ENGINE_NAME := YaneuraOu_NNUE_HALFKPE9
+      ARCH_DEF += -DEVAL_NNUE_HALFKPE9
     endif
   endif
 endif
@@ -179,6 +188,8 @@ LOCAL_SRC_FILES += \
   ../source/eval/nnue/features/p.cpp                                   \
   ../source/eval/nnue/features/half_kp.cpp                             \
   ../source/eval/nnue/features/half_relative_kp.cpp                    \
+  ../source/eval/nnue/features/half_kpe9.cpp                           \
+  ../source/eval/nnue/features/pe9.cpp                                 \
   ../source/engine/yaneuraou-engine/yaneuraou-search.cpp
 endif
 

--- a/script/android_build.sh
+++ b/script/android_build.sh
@@ -38,6 +38,7 @@ DIRSTR=(
   ["YANEURAOU_ENGINE_KPP_KKPT"]="KPP_KKPT"
   ["YANEURAOU_ENGINE_MATERIAL"]="KOMA"
   ["MATE_ENGINE"]="MATE"
+  ["USER_ENGINE"]="USER"
 );
 
 set -f
@@ -48,11 +49,11 @@ for EDITION in ${EDITIONS[@]}; do
     if [[ $EDITION == $EDITIONPTN ]]; then
       set -f
       echo "* edition: ${EDITION}"
-      BUILDDIR=../build/android/${DIRSTR[$EDITION]}
+      BUILDDIR=build/android/${DIRSTR[$EDITION]}
       mkdir -p ${BUILDDIR}
       ndk-build clean ENGINE_TARGET=${EDITION}
-      ndk-build ENGINE_TARGET=${EDITION} -j${JOBS} > >(tee build/android/${DIRSTR[$EDITION]}/${DIRSTR[$EDITION]}.log) || exit $?
-      cp libs/**/* build/android/${DIRSTR[$EDITION]}
+      ndk-build ENGINE_TARGET=${EDITION} V=1 -j${JOBS} > >(tee ${BUILDDIR}/build.log) || exit $?
+      bash -c "cp libs/**/* ${BUILDDIR}"
       ndk-build clean ENGINE_TARGET=${EDITION}
       break
     fi


### PR DESCRIPTION
- ` jni/Android.mk` にてHALFKPE9対応してなかったので修正
- `script/android_build.sh` にて
  - `USER_ENGINE` の出力ディレクトリ指定してなかった
  - glob込みでのコピー操作が何故か失敗するので対策ぽく
  - 出力ログファイル名を `build.log` に変更
  - ビルド時のログ出力を詳細に
  - 出力先ディレクトリの不整合を起こしていたので修正

ShogiDroid用動作サンプルzip: eval Sylwi(2020-05) + YOv5.21 trunk
https://github.com/mizar/YaneuraOu/releases/download/v5.21-20201106b_androidfix/Sylwi-YO5.21-android.zip