### PR TITLE
- android build fix, and checkout path change to ./main

### DIFF
--- a/.github/workflows/make-mingw.yml
+++ b/.github/workflows/make-mingw.yml
@@ -57,7 +57,10 @@ jobs:
             archcpu: NO_SSE
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout own repository
+      uses: actions/checkout@v2
+      with:
+        path: main
 
     - name: install openblas
       run: |
@@ -65,9 +68,9 @@ jobs:
         sudo apt install build-essential mingw-w64 libopenblas-dev libomp-dev libomp5
 
     - name: make
-      run: ./script/mingw_gcc.sh -e ${{ matrix.edition }} -c ${{ matrix.compiler }} -t ${{ matrix.target }} -a ${{ matrix.archcpu }}
+      run: ./main/script/mingw_gcc.sh -e ${{ matrix.edition }} -c ${{ matrix.compiler }} -t ${{ matrix.target }} -a ${{ matrix.archcpu }}
 
     - uses: actions/upload-artifact@v2
       with:
         name: build-mingw
-        path: build/**/**/*
+        path: ./main/build/**/*

--- a/.github/workflows/make-msys2.yml
+++ b/.github/workflows/make-msys2.yml
@@ -39,7 +39,10 @@ jobs:
             target: evallearn
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout own repository
+      uses: actions/checkout@v2
+      with:
+        path: main
 
     - name: Install pkg
       run: |
@@ -50,9 +53,9 @@ jobs:
     - name: make
       run: |
         $env:PATH+=';C:\msys64';
-        .\script\msys2_build.ps1 -Edition ${{ matrix.edition }} -Compiler ${{ matrix.compiler }} -Target ${{ matrix.target }}
+        .\main\script\msys2_build.ps1 -Edition ${{ matrix.edition }} -Compiler ${{ matrix.compiler }} -Target ${{ matrix.target }}
 
     - uses: actions/upload-artifact@v2
       with:
         name: build-windows
-        path: build/**/*
+        path: ./main/build/**/*

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -47,7 +47,10 @@ jobs:
           - archcpu: NO_SSE
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout own repository
+      uses: actions/checkout@v2
+      with:
+        path: main
 
     - name: install openblas
       run: |
@@ -55,9 +58,9 @@ jobs:
         sudo apt install build-essential clang-10 g++-8 libopenblas-dev libomp-dev libomp5
 
     - name: make
-      run: cd script && ./build.sh -e ${{ matrix.edition }} -c ${{ matrix.compiler }} -t ${{ matrix.target }} -a ${{ matrix.archcpu }}
+      run: ./main/script/build.sh -e ${{ matrix.edition }} -c ${{ matrix.compiler }} -t ${{ matrix.target }} -a ${{ matrix.archcpu }}
 
     - uses: actions/upload-artifact@v2
       with:
         name: build-linux
-        path: build/**/**/*
+        path: ./main/build/**/**/*

--- a/.github/workflows/ndk.yml
+++ b/.github/workflows/ndk.yml
@@ -28,16 +28,20 @@ jobs:
           - USER_ENGINE
 
     steps:
-    - uses: actions/checkout@v2
-
-    - uses: nttld/setup-ndk@v1
+    - name: Setup Android NDK r21d
+      uses: nttld/setup-ndk@v1
       with:
         ndk-version: r21d
 
+    - name: Checkout own repository
+      uses: actions/checkout@v2
+      with:
+        path: main
+
     - name: ndk-build
-      run: ./script/android_build.sh -e ${{ matrix.edition }}
+      run: ./main/script/android_build.sh -e ${{ matrix.edition }}
 
     - uses: actions/upload-artifact@v2
       with:
         name: build-android
-        path: build/**/*
+        path: ./main/build/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,10 @@ jobs:
             target: evallearn
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout own repository
+      uses: actions/checkout@v2
+      with:
+        path: main
 
     - name: Install pkg
       run: |
@@ -58,12 +61,12 @@ jobs:
     - name: make
       run: |
         $env:PATH+=';C:\msys64';
-        .\script\msys2_build.ps1 -Edition ${{ matrix.edition }} -Compiler ${{ matrix.compiler }} -Target ${{ matrix.target }} -Cpu ${{ matrix.archcpu }}
+        .\main\script\msys2_build.ps1 -Edition ${{ matrix.edition }} -Compiler ${{ matrix.compiler }} -Target ${{ matrix.target }} -Cpu ${{ matrix.archcpu }}
 
     - uses: actions/upload-artifact@v2
       with:
         name: build-windows
-        path: build/**/*
+        path: ./main/build/**/*
 
   build-android:
     # ubuntu-latest = ubuntu-18.04
@@ -86,19 +89,23 @@ jobs:
           - edition: USER_ENGINE
 
     steps:
-    - uses: actions/checkout@v2
-
-    - uses: nttld/setup-ndk@v1
+    - name: Setup Android NDK r21d
+      uses: nttld/setup-ndk@v1
       with:
         ndk-version: r21d
 
+    - name: Checkout own repository
+      uses: actions/checkout@v2
+      with:
+        path: main
+
     - name: ndk-build
-      run: ./script/android_build.sh -e ${{ matrix.edition }}
+      run: ./main/script/android_build.sh -e ${{ matrix.edition }}
 
     - uses: actions/upload-artifact@v2
       with:
         name: build-android
-        path: build/**/*
+        path: ./main/build/**/*
 
   release-pkg:
     name: Release package

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -16,60 +16,69 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-ARCH_DEF := -DTARGET_ARCH="$(TARGET_ARCH_ABI)"
+CPPFLAGS := -DTARGET_ARCH="$(TARGET_ARCH_ABI)"
 
 # example: (default build target)
 # $ ndk-build
 
-# example: 2018 Otafuku (EVAL_KPPT)
-# $ ndk-build ENGINE_TARGET=YANEURAOU_ENGINE_KPPT
+# example: EVAL_KPPT
+# $ ndk-build YANEURAOU_EDITION=YANEURAOU_ENGINE_KPPT
 
-# example: 2018 Otafuku (EVAL_KPP_KKPT)
-# $ ndk-build ENGINE_TARGET=YANEURAOU_ENGINE_KPP_KKPT
+# example: EVAL_KPP_KKPT
+# $ ndk-build YANEURAOU_EDITION=YANEURAOU_ENGINE_KPP_KKPT
 
-# example: 2018 Otafuku (EVAL_MATERIAL)
-# $ ndk-build ENGINE_TARGET=YANEURAOU_ENGINE_MATERIAL
+# example: EVAL_MATERIAL (KOMA)
+# $ ndk-build YANEURAOU_EDITION=YANEURAOU_ENGINE_MATERIAL
 
-# example: 2018 T.N.K. (EVAL_NNUE_HALFKP_256x2_32_32)
-# $ ndk-build ENGINE_TARGET=YANEURAOU_ENGINE_NNUE
+# example: EVAL_NNUE_HALFKP_256x2_32_32 (2018 T.N.K.)
+# $ ndk-build YANEURAOU_EDITION=YANEURAOU_ENGINE_NNUE
 
-# example: 2018 T.N.K. (EVAL_NNUE_K_P_256x2_32_32)
-# $ ndk-build ENGINE_TARGET=YANEURAOU_ENGINE_NNUE NNUE_EVAL_ARCH=KP256
+# example: EVAL_NNUE_HALFKPE9_256x2_32_32
+# $ ndk-build YANEURAOU_EDITION=YANEURAOU_ENGINE_NNUE_HALFKPE9
 
-# example: tnk- Mate (MATE_ENGINE)
-# $ ndk-build ENGINE_TARGET=MATE_ENGINE
+# example: EVAL_NNUE_K_P_256x2_32_32
+# $ ndk-build YANEURAOU_EDITION=YANEURAOU_ENGINE_NNUE_KP256
 
-ENGINE_TARGET := YANEURAOU_ENGINE_NNUE
-#ENGINE_TARGET := YANEURAOU_ENGINE_KPPT
-#ENGINE_TARGET := YANEURAOU_ENGINE_KPP_KKPT
-#ENGINE_TARGET := YANEURAOU_ENGINE_MATERIAL
-#ENGINE_TARGET := MATE_ENGINE
+# example: MATE_ENGINE (tanuki_MATE)
+# $ ndk-build YANEURAOU_EDITION=MATE_ENGINE
 
-# エンジンの表示名("usi"コマンドに対して出力される)
+YANEURAOU_EDITION := YANEURAOU_ENGINE_NNUE
+#YANEURAOU_EDITION := YANEURAOU_ENGINE_NNUE_HALFKPE9
+#YANEURAOU_EDITION := YANEURAOU_ENGINE_NNUE_KP256
+#YANEURAOU_EDITION := YANEURAOU_ENGINE_KPPT
+#YANEURAOU_EDITION := YANEURAOU_ENGINE_KPP_KKPT
+#YANEURAOU_EDITION := YANEURAOU_ENGINE_MATERIAL
+#YANEURAOU_EDITION := MATE_ENGINE
+#YANEURAOU_EDITION := USER_ENGINE
+
+# エンジンの表示名 (engine displayname)
+# ("usi"コマンドに対して出力される)
 #ENGINE_NAME :=
 
-# 開発中のbranchならdevと指定する
+# developing branch // 現状、非公開 (currently private)
+# dev : 開発中のbranchならdevと指定する (developing branch) : 
+# abe : abe
 #ENGINE_BRANCH := dev
 
-ifeq ($(ENGINE_TARGET),YANEURAOU_ENGINE_KPPT)
-  ARCH_DEF += -DUSE_MAKEFILE -DYANEURAOU_ENGINE_KPPT
+ifeq ($(YANEURAOU_EDITION),YANEURAOU_ENGINE_KPPT)
+  CPPFLAGS += -DUSE_MAKEFILE -DYANEURAOU_ENGINE_KPPT
   ENGINE_NAME := YaneuraOu_KPPT
 endif
 
-ifeq ($(ENGINE_TARGET),YANEURAOU_ENGINE_KPP_KKPT)
-  ARCH_DEF += -DUSE_MAKEFILE -DYANEURAOU_ENGINE_KPP_KKPT
+ifeq ($(YANEURAOU_EDITION),YANEURAOU_ENGINE_KPP_KKPT)
+  CPPFLAGS += -DUSE_MAKEFILE -DYANEURAOU_ENGINE_KPP_KKPT
   ENGINE_NAME := YaneuraOu_KPP_KKPT
 endif
 
-ifeq ($(ENGINE_TARGET),YANEURAOU_ENGINE_MATERIAL)
-  ARCH_DEF += -DUSE_MAKEFILE -DYANEURAOU_ENGINE_MATERIAL
+ifeq ($(YANEURAOU_EDITION),YANEURAOU_ENGINE_MATERIAL)
+  CPPFLAGS += -DUSE_MAKEFILE -DYANEURAOU_ENGINE_MATERIAL
   ENGINE_NAME := YaneuraOu_KOMA
 endif
 
-ifeq ($(findstring YANEURAOU_ENGINE_NNUE,$(ENGINE_TARGET)),YANEURAOU_ENGINE_NNUE)
-  ARCH_DEF += -DUSE_MAKEFILE -DYANEURAOU_ENGINE_NNUE
+ifeq ($(findstring YANEURAOU_ENGINE_NNUE,$(YANEURAOU_EDITION)),YANEURAOU_ENGINE_NNUE)
+  CPPFLAGS += -DUSE_MAKEFILE -DYANEURAOU_ENGINE_NNUE
   ENGINE_NAME := YaneuraOu_NNUE
-  ifeq ($(ENGINE_TARGET),YANEURAOU_ENGINE_NNUE_KP256)
+  ifeq ($(YANEURAOU_EDITION),YANEURAOU_ENGINE_NNUE_KP256)
     ENGINE_NAME := YaneuraOu_NNUE_KP256
     CPPFLAGS += -DEVAL_NNUE_KP256
   else
@@ -78,44 +87,44 @@ ifeq ($(findstring YANEURAOU_ENGINE_NNUE,$(ENGINE_TARGET)),YANEURAOU_ENGINE_NNUE
       CPPFLAGS += -DEVAL_NNUE_KP256
     endif
   endif
+  ifeq ($(YANEURAOU_EDITION),YANEURAOU_ENGINE_NNUE_HALFKPE9)
+    ENGINE_NAME := YaneuraOu_NNUE_HALFKPE9
+    CPPFLAGS += -DEVAL_NNUE_HALFKPE9
+  else
+    ifeq ($(NNUE_EVAL_ARCH),HALFKPE9)
+      ENGINE_NAME := YaneuraOu_NNUE_HALFKPE9
+      CPPFLAGS += -DEVAL_NNUE_HALFKPE9
+    endif
+  endif
 endif
 
-ifeq ($(ENGINE_TARGET),MATE_ENGINE)
-  ARCH_DEF += -DUSE_MAKEFILE -DMATE_ENGINE
+ifeq ($(YANEURAOU_EDITION),MATE_ENGINE)
+  CPPFLAGS += -DUSE_MAKEFILE -DMATE_ENGINE
   ENGINE_NAME := tanuki_MATE
 endif
 
-ifeq ($(ENGINE_TARGET),USER_ENGINE)
-  ARCH_DEF += -DUSE_MAKEFILE -DUSER_ENGINE
+ifeq ($(YANEURAOU_EDITION),USER_ENGINE)
+  CPPFLAGS += -DUSE_MAKEFILE -DUSER_ENGINE
   ENGINE_NAME := YaneuraOu_USER
 endif
 
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
-  ARCH_DEF += -DIS_64BIT -DIS_ARM -mfpu=neon
+  CPPFLAGS += -DIS_64BIT -DUSE_NEON -mfpu=neon
   LOCAL_ARM_NEON := true
 endif
 
 ifeq ($(TARGET_ARCH_ABI),x86_64)
-  ARCH_DEF += -DIS_64BIT -DUSE_SSE42 -msse4.2
+  CPPFLAGS += -DIS_64BIT -DUSE_SSE42 -msse4.2
 endif
 
 ifeq ($(TARGET_ARCH_ABI),x86)
-  ARCH_DEF += -DNO_SSE
+  CPPFLAGS += -DNO_SSE
 endif
 
 ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
-  ARCH_DEF += -DIS_ARM -mfpu=neon
+  CPPFLAGS += -DUSE_NEON -mfpu=neon
   LOCAL_ARM_NEON := true
 endif
-
-LOCAL_MODULE    := $(ENGINE_NAME)_$(TARGET_ARCH_ABI)
-LOCAL_CXXFLAGS  := -std=c++17 -fno-exceptions -fno-rtti -Wextra -Ofast -MMD -MP -fpermissive -D__STDINT_MACROS -D__STDC_LIMIT_MACROS $(ARCH_DEF)
-LOCAL_CXXFLAGS += -fPIE -Wno-unused-parameter
-LOCAL_LDFLAGS += -fPIE -pie -flto
-LOCAL_LDLIBS =
-LOCAL_C_INCLUDES :=
-LOCAL_CPP_FEATURES += exceptions rtti
-#LOCAL_STATIC_LIBRARIES    := -lpthread
 
 LOCAL_SRC_FILES := \
   ../source/main.cpp                                                   \
@@ -150,14 +159,14 @@ LOCAL_SRC_FILES := \
   ../source/learn/learning_tools.cpp                                   \
   ../source/learn/multi_think.cpp
 
-ifeq ($(ENGINE_TARGET),YANEURAOU_ENGINE_KPPT)
+ifeq ($(YANEURAOU_EDITION),YANEURAOU_ENGINE_KPPT)
 LOCAL_SRC_FILES += \
   ../source/eval/kppt/evaluate_kppt.cpp                                \
   ../source/eval/kppt/evaluate_kppt_learner.cpp                        \
   ../source/engine/yaneuraou-engine/yaneuraou-search.cpp
 endif
 
-ifeq ($(ENGINE_TARGET),YANEURAOU_ENGINE_KPP_KKPT)
+ifeq ($(YANEURAOU_EDITION),YANEURAOU_ENGINE_KPP_KKPT)
 LOCAL_SRC_FILES += \
   ../source/eval/kppt/evaluate_kppt.cpp                                \
   ../source/eval/kpp_kkpt/evaluate_kpp_kkpt.cpp                        \
@@ -165,12 +174,12 @@ LOCAL_SRC_FILES += \
   ../source/engine/yaneuraou-engine/yaneuraou-search.cpp
 endif
 
-ifeq ($(ENGINE_TARGET),YANEURAOU_ENGINE_MATERIAL)
+ifeq ($(YANEURAOU_EDITION),YANEURAOU_ENGINE_MATERIAL)
 LOCAL_SRC_FILES += \
   ../source/engine/yaneuraou-engine/yaneuraou-search.cpp
 endif
 
-ifeq ($(findstring YANEURAOU_ENGINE_NNUE,$(ENGINE_TARGET)),YANEURAOU_ENGINE_NNUE)
+ifeq ($(findstring YANEURAOU_ENGINE_NNUE,$(YANEURAOU_EDITION)),YANEURAOU_ENGINE_NNUE)
 LOCAL_SRC_FILES += \
   ../source/eval/nnue/evaluate_nnue.cpp                                \
   ../source/eval/nnue/evaluate_nnue_learner.cpp                        \
@@ -179,27 +188,47 @@ LOCAL_SRC_FILES += \
   ../source/eval/nnue/features/p.cpp                                   \
   ../source/eval/nnue/features/half_kp.cpp                             \
   ../source/eval/nnue/features/half_relative_kp.cpp                    \
+  ../source/eval/nnue/features/half_kpe9.cpp                           \
+  ../source/eval/nnue/features/pe9.cpp                                 \
   ../source/engine/yaneuraou-engine/yaneuraou-search.cpp
 endif
 
-ifeq ($(ENGINE_TARGET),MATE_ENGINE)
+ifeq ($(YANEURAOU_EDITION),MATE_ENGINE)
 LOCAL_SRC_FILES += \
 	../source/engine/mate-engine/mate-search.cpp
 endif
 
-ifeq ($(ENGINE_TARGET),USER_ENGINE)
+ifeq ($(YANEURAOU_EDITION),USER_ENGINE)
 LOCAL_SRC_FILES += \
 	../source/engine/user-engine/user-search.cpp
 endif
 
 ifneq ($(ENGINE_NAME),)
-	CPPFLAGS += -DENGINE_NAME_FROM_MAKEFILE=$(ENGINE_NAME)
+CPPFLAGS += -DENGINE_NAME_FROM_MAKEFILE=$(ENGINE_NAME)
 endif
 
 # 開発用branch
 ifeq ($(findstring dev,$(ENGINE_BRANCH)),dev)
+CPPFLAGS += -DDEV_BRANCH
 LOCAL_SRC_FILES += \
-  ../source/extra/SuperSort.cpp
+  ../source/extra/super_sort.cpp
 endif
+
+# abe
+ifeq ($(findstring abe,$(ENGINE_BRANCH)),abe)
+CPPFLAGS += -DPV_OUTPUT_DRAW_ONLY
+LOCAL_SRC_FILES += \
+  ../source/extra/super_sort.cpp
+endif
+
+
+LOCAL_MODULE    := $(ENGINE_NAME)_$(TARGET_ARCH_ABI)
+LOCAL_CXXFLAGS  := -std=c++17 -fno-exceptions -fno-rtti -Wextra -Ofast -MMD -MP -fpermissive -D__STDINT_MACROS -D__STDC_LIMIT_MACROS $(CPPFLAGS)
+LOCAL_CXXFLAGS += -DNDEBUG -fPIE -Wno-unused-parameter -flto
+LOCAL_LDFLAGS += -fPIE -pie -flto
+LOCAL_LDLIBS =
+LOCAL_C_INCLUDES :=
+#LOCAL_CPP_FEATURES += exceptions rtti
+#LOCAL_STATIC_LIBRARIES    := -lpthread
 
 include $(BUILD_EXECUTABLE)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,3 +1,3 @@
-APP_ABI := arm64-v8a x86_64 armeabi-v7a x86
+APP_ABI := all
 APP_STL := c++_static
 APP_PLATFORM = android-19

--- a/script/android_build.ps1
+++ b/script/android_build.ps1
@@ -58,11 +58,11 @@ if(-not (Test-Path $Dir)){
 }
 
 "`n* Clean Build"|Out-Host;
-ndk-build.cmd clean ENGINE_TARGET=$_Edition;
+ndk-build.cmd clean YANEURAOU_EDITION=$_Edition;
 
 "`n* Build Binary"|Out-Host;
 $log = $null;
-ndk-build.cmd ENGINE_TARGET=$_Edition NNUE_EVAL_ARCH=$($_.Nnue) V=1 -j $Jobs|Tee-Object -Variable log;
+ndk-build.cmd YANEURAOU_EDITION=$_Edition NNUE_EVAL_ARCH=$($_.Nnue) V=1 -j $Jobs|Tee-Object -Variable log;
 $log|Out-File -Encoding utf8 -Force (Join-Path $Dir "build.log");
 
 "`n* Copy Binary"|Out-Host;
@@ -72,7 +72,7 @@ ForEach-Object{
 };
 
 "`n* Clean Build"|Out-Host;
-ndk-build.cmd clean ENGINE_TARGET=$_Edition;
+ndk-build.cmd clean YANEURAOU_EDITION=$_Edition;
 
 }
 

--- a/script/android_build.sh
+++ b/script/android_build.sh
@@ -38,6 +38,7 @@ DIRSTR=(
   ["YANEURAOU_ENGINE_KPP_KKPT"]="KPP_KKPT"
   ["YANEURAOU_ENGINE_MATERIAL"]="KOMA"
   ["MATE_ENGINE"]="MATE"
+  ["USER_ENGINE"]="USER"
 );
 
 set -f
@@ -48,12 +49,12 @@ for EDITION in ${EDITIONS[@]}; do
     if [[ $EDITION == $EDITIONPTN ]]; then
       set -f
       echo "* edition: ${EDITION}"
-      BUILDDIR=../build/android/${DIRSTR[$EDITION]}
+      BUILDDIR=build/android/${DIRSTR[$EDITION]}
       mkdir -p ${BUILDDIR}
-      ndk-build clean ENGINE_TARGET=${EDITION}
-      ndk-build ENGINE_TARGET=${EDITION} -j${JOBS} > >(tee build/android/${DIRSTR[$EDITION]}/${DIRSTR[$EDITION]}.log) || exit $?
-      cp libs/**/* build/android/${DIRSTR[$EDITION]}
-      ndk-build clean ENGINE_TARGET=${EDITION}
+      ndk-build clean YANEURAOU_EDITION=${EDITION}
+      ndk-build YANEURAOU_EDITION=${EDITION} V=1 -j${JOBS} > >(tee ${BUILDDIR}/build.log) || exit $?
+      bash -c "cp libs/**/* ${BUILDDIR}"
+      ndk-build clean YANEURAOU_EDITION=${EDITION}
       break
     fi
     set -f

--- a/source/eval/nnue/layers/affine_transform.h
+++ b/source/eval/nnue/layers/affine_transform.h
@@ -95,7 +95,7 @@ class AffineTransform {
     const __m128i kOnes = _mm_set1_epi16(1);
     const auto input_vector = reinterpret_cast<const __m128i*>(input);
 
-#elif defined(IS_ARM)
+#elif defined(USE_NEON)
     constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
     const auto input_vector = reinterpret_cast<const int8x8_t*>(input);
 
@@ -130,7 +130,7 @@ class AffineTransform {
       sum = _mm_hadd_epi32(sum, sum);
       sum = _mm_hadd_epi32(sum, sum);
       output[i] = _mm_cvtsi128_si32(sum);
-#elif defined(IS_ARM)
+#elif defined(USE_NEON)
       int32x4_t sum = {biases_[i]};
       const auto row = reinterpret_cast<const int8x8_t*>(&weights_[offset]);
       for (IndexType j = 0; j < kNumChunks; ++j) {

--- a/source/eval/nnue/layers/clipped_relu.h
+++ b/source/eval/nnue/layers/clipped_relu.h
@@ -113,7 +113,7 @@ class ClippedReLU {
     }
     constexpr IndexType kStart = kNumChunks * kSimdWidth;
 
-#elif defined(IS_ARM)
+#elif defined(USE_NEON)
     constexpr IndexType kNumChunks = kInputDimensions / (kSimdWidth / 2);
     const int8x8_t kZero = {0};
     const auto in = reinterpret_cast<const int32x4_t*>(input);

--- a/source/eval/nnue/nnue_common.h
+++ b/source/eval/nnue/nnue_common.h
@@ -26,7 +26,7 @@ constexpr std::size_t kCacheLineSize = 64;
 constexpr std::size_t kSimdWidth = 32;
 #elif defined(USE_SSE2)
 constexpr std::size_t kSimdWidth = 16;
-#elif defined(IS_ARM)
+#elif defined(USE_NEON)
 constexpr std::size_t kSimdWidth = 16;
 #endif
 constexpr std::size_t kMaxSimdWidth = 32;

--- a/source/eval/nnue/nnue_feature_transformer.h
+++ b/source/eval/nnue/nnue_feature_transformer.h
@@ -97,7 +97,7 @@ class FeatureTransformer {
     const __m128i k0x80s = _mm_set1_epi8(-128);
 #endif
 
-#elif defined(IS_ARM)
+#elif defined(USE_NEON)
     constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
     const int8x8_t kZero = {0};
 #endif
@@ -144,7 +144,7 @@ class FeatureTransformer {
         );
 
       }
-#elif defined(IS_ARM)
+#elif defined(USE_NEON)
       const auto out = reinterpret_cast<int8x8_t*>(&output[offset]);
       for (IndexType j = 0; j < kNumChunks; ++j) {
         int16x8_t sum = reinterpret_cast<const int16x8_t*>(
@@ -202,7 +202,7 @@ class FeatureTransformer {
           for (IndexType j = 0; j < kNumChunks; ++j) {
             accumulation[j] = _mm_add_epi16(accumulation[j], column[j]);
           }
-#elif defined(IS_ARM)
+#elif defined(USE_NEON)
           auto accumulation = reinterpret_cast<int16x8_t*>(
               &accumulator.accumulation[perspective][i][0]);
           auto column = reinterpret_cast<const int16x8_t*>(&weights_[offset]);
@@ -241,7 +241,7 @@ class FeatureTransformer {
         constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
         auto accumulation = reinterpret_cast<__m128i*>(
             &accumulator.accumulation[perspective][i][0]);
-#elif defined(IS_ARM)
+#elif defined(USE_NEON)
         constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
         auto accumulation = reinterpret_cast<int16x8_t*>(
             &accumulator.accumulation[perspective][i][0]);
@@ -270,7 +270,7 @@ class FeatureTransformer {
             for (IndexType j = 0; j < kNumChunks; ++j) {
               accumulation[j] = _mm_sub_epi16(accumulation[j], column[j]);
             }
-#elif defined(IS_ARM)
+#elif defined(USE_NEON)
             auto column = reinterpret_cast<const int16x8_t*>(&weights_[offset]);
             for (IndexType j = 0; j < kNumChunks; ++j) {
               accumulation[j] = vsubq_s16(accumulation[j], column[j]);
@@ -296,7 +296,7 @@ class FeatureTransformer {
             for (IndexType j = 0; j < kNumChunks; ++j) {
               accumulation[j] = _mm_add_epi16(accumulation[j], column[j]);
             }
-#elif defined(IS_ARM)
+#elif defined(USE_NEON)
             auto column = reinterpret_cast<const int16x8_t*>(&weights_[offset]);
             for (IndexType j = 0; j < kNumChunks; ++j) {
               accumulation[j] = vaddq_s16(accumulation[j], column[j]);

--- a/source/extra/bitop.h
+++ b/source/extra/bitop.h
@@ -31,7 +31,7 @@
 #include <tmmintrin.h>
 #elif defined(USE_SSE2)
 #include <emmintrin.h>
-#elif defined(IS_ARM)
+#elif defined(USE_NEON)
 #include <arm_neon.h>
 #include <mm_malloc.h> // for _mm_alloc()
 #else


### PR DESCRIPTION
- Android HalfKPE9ビルドの修正、他諸々
- 自動ビルドにおいて、gitレポジトリの展開先をカレントディレクトリから`./main`に変更

ShogiDroid向けHalfKPE9実行サンプル:
https://github.com/mizar/YaneuraOu/releases/download/v5.30-20201107c_androidfix/YOv5.30-Sylwi.zip