### PR TITLE
- bench.py

### DIFF
--- a/script/bench.py
+++ b/script/bench.py
@@ -1,0 +1,193 @@
+#!/usr/bin/python3
+import yaml
+import pexpect
+import pexpect.popen_spawn
+import pandas
+import statsmodels.stats.weightstats
+import cpuid
+import re
+import argparse
+import platform
+import logging
+
+# python package install (Windows):
+# https://www.microsoft.com/store/productId/9P7QFQMJRFP7
+# python3 -m pip install cpuid pandas pexpect pyyaml statsmodels numpy==1.19.3
+
+# python package install (Ubuntu):
+# sudo apt-get update
+# sudo apt-get install python3 python3-pip
+# python3 -m pip install cpuid pandas pexpect pyyaml statsmodels numpy
+
+# python package list:
+# python3 -m pip list
+# python3 -m pip list --outdated
+
+pandas.options.display.float_format = '{:11.0f}'.format
+
+parser = argparse.ArgumentParser(description='bench')
+parser.add_argument('--cmd', dest='cmd', default='')
+parser.add_argument('--loop', type=int, default=1)
+parser.add_argument('--log', dest='log', default='bench.log')
+parser.add_argument('engine1')
+parser.add_argument('eval1')
+parser.add_argument('engine2', default=None, nargs='?')
+parser.add_argument('eval2', default=None, nargs='?')
+
+args = parser.parse_args()
+
+logging.basicConfig(format='%(asctime)s %(message)s', filename=args.log, level=logging.DEBUG)
+logger = logging.getLogger('bench')
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s %(message)s')
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+logger.info('OS: %s' % platform.system())
+logger.info(yaml.dump(args).replace(r"!!python/object:argparse.Namespace", ''))
+
+class YOBench():
+  def __init__(self, path, eval, cmd):
+    self.path = path
+    self.eval = eval
+    self.cmd = cmd
+
+  def exec(self):
+    rlines = ""
+    child = pexpect.spawn(self.path) if platform.system() != "Windows" else pexpect.popen_spawn.PopenSpawn(self.path.replace("\\", "/"))
+    child.sendline("setoption name EvalDir value %s" % self.eval)
+    child.sendline("isready")
+    child.expect(r"readyok\s*\n", 60)
+    rlines += child.before.decode("cp932", errors="ignore")
+    rlines += child.after.decode("cp932", errors="ignore")
+    child.sendline("bench %s" % self.cmd)
+    child.expect(r"Nodes\/second +: \d+\s*\n", 600)
+    rlines += child.before.decode("cp932", errors="ignore")
+    rlines += child.after.decode("cp932", errors="ignore")
+    child.sendline("quit")
+    if platform.system() != "Windows":
+      child.close()
+    return rlines
+
+ptn1 = re.compile(r'Total time \(ms\) +: (?P<time_e1>\d+)\s+Nodes searched +: (?P<nodes_e1>\d+)\s+Nodes\/second +: (?P<nps_e1>\d+)')
+ptn2 = re.compile(r'Total time \(ms\) +: (?P<time_e2>\d+)\s+Nodes searched +: (?P<nodes_e2>\d+)\s+Nodes\/second +: (?P<nps_e2>\d+)')
+
+bench1 = YOBench(args.engine1, args.eval1, args.cmd)
+bench2 = YOBench(args.engine2, args.eval2, args.cmd)
+
+dlist = []
+
+print('run       base       test     diff')
+for i in range(args.loop):
+  print('{:3d} '.format(i + 1), end='', flush=True)
+  dic = {}
+
+  if args.engine1 is not None :
+    logger.debug('run {:d} {:s}'.format(i + 1, args.engine1))
+    res = bench1.exec()
+    logger.debug(res)
+    m = ptn1.search(res).groupdict()
+    if m is not None :
+      for k, v in m.items():
+        m[k] = int(v)
+      dic.update(m)
+      print('{:10d} '.format(m['nps_e1']), end='', flush=True)
+
+  if args.engine2 is not None :
+    logger.debug('run {:d} {:s}'.format(i + 1, args.engine2))
+    res = bench2.exec()
+    logger.debug(res)
+    m = ptn2.search(res).groupdict()
+    if m is not None :
+      for k, v in m.items():
+        m[k] = int(v)
+      dic.update(m)
+      print('{:10d} '.format(m['nps_e2']), end='', flush=True)
+
+  if 'nps_e2' in dic :
+    dic['nps_diff'] = dic['nps_e2'] - dic['nps_e1']
+    print('{:+8d}'.format(dic['nps_diff']), flush=True)
+
+    logger.debug('run       base       test     diff')
+    logger.debug('{:3d} {:10d} {:10d} {:+8d}'.format(
+      i + 1,
+      dic['nps_e1'],
+      dic['nps_e2'],
+      dic['nps_diff'],
+    ))
+  else:
+    print()
+    logger.debug('{:3d} {:10d}'.format(
+      i + 1,
+      dic['nps_e1']
+    ))
+
+  dlist.append(dic)
+
+df = pandas.json_normalize(dlist)
+df_mean = df.mean()
+df_std = df.std()
+
+if args.engine2 is not None :
+  logger.info('''
+
+{:s}
+
+{:s}
+
+Result of {:d} runs
+==================
+base           = {:10.0f} +/- {:.0f}
+test           = {:10.0f} +/- {:.0f}
+diff           = {:+10.0f} +/- {:.0f}
+
+speedup        = {:+.4f}
+P(speedup > 0) = {:.4f}
+
+Vendor ID         : {:s}
+CPU Name          : {:s}
+Microarchitecture : {:s}
+
+'''.format(
+    str(df),
+    str(df.describe()),
+    args.loop,
+    df_mean['nps_e1'], df_std['nps_e1'],
+    df_mean['nps_e2'], df_std['nps_e2'],
+    df_mean['nps_diff'], df_std['nps_diff'],
+    df_mean['nps_diff'] / df_mean['nps_e1'],
+    statsmodels.stats.weightstats.ttest_ind(
+      df['nps_e1'].values,
+      df['nps_e2'].values,
+      alternative='larger',
+      usevar='unequal'
+    )[1],
+    cpuid.cpu_vendor(),
+    cpuid.cpu_name(),
+    '%s%s' % cpuid.cpu_microarchitecture()
+  ))
+else:
+  logger.info('''
+
+{:s}
+
+{:s}
+
+Result of {:d} runs
+==================
+base           = {:10.0f} +/- {:.0f}
+
+Vendor ID         : {:s}
+CPU Name          : {:s}
+Microarchitecture : {:s}
+
+'''.format(
+    str(df),
+    str(df.describe()),
+    args.loop,
+    df_mean['nps_e1'], df_std['nps_e1'],
+    cpuid.cpu_vendor(),
+    cpuid.cpu_name(),
+    '%s%s' % cpuid.cpu_microarchitecture()
+  ))


### PR DESCRIPTION
やねうら王エンジンのベンチマーク測定

```
usage: bench.py [-h] [--cmd CMD] [--loop LOOP] [--log LOG] engine1 eval1 [engine2] [eval2]
```

- python3 をインストールします。
  - Windows 10 なら、例えば Microsoft Store から: https://www.microsoft.com/store/productId/9P7QFQMJRFP7
- 必要なら、 python3 の pip パッケージを更新します。
  - `python3 -m pip install --upgrade pip`
- 必要なpythonパッケージをインストールします。（python3のインストール形態によっては管理者権限が必要な事があります）
  - `python3 -m pip install cpuid pandas pexpect pyyaml statsmodels numpy==1.19.3`
- 実行例として、2つのエンジンと評価関数を使い、交互にベンチマークを行います。
  - `python3 script/bench.py --cmd "16384 64 30 default time" --loop 10 /path/engine/original/Yaneuraou_NNUE-linux-clang++-10-tournament-ZEN2 /path/eval/original_NNUE/eval /path/engine/new/Yaneuraou_NNUE-linux-clang++-12-tournament-ZEN2 /path/eval/new_NNUE/eval`
  - USI_Hash=16384 (16GB), Threads=64, 1局面30秒, デフォルトの3局面 によるベンチマークが各10回、1つ目のエンジン・1つ目の評価関数と、2つ目のエンジン・2つ目の評価関数、の間で交互にベンチマーク測定が行われます。
  - 上記の例では、 30秒 * 3局面 * 2エンジン * 10回 の測定でベンチマークの完了まで約30分掛かります。
  - コマンドオプションの詳細: https://github.com/yaneurao/YaneuraOu/blob/24613c705269ef70411486179947ca61275f590a/docs/USI%E6%8B%A1%E5%BC%B5%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89.txt#L299-L309
- 実行結果のログが出力されます。デフォルト: `bench.log`

![image](https://user-images.githubusercontent.com/68691/99940881-66f8af80-2db0-11eb-92fb-91d245b1730a.png)
実行例。この場合は `P(speedup > 0) = 0.0000` 、**この測定条件に於いては**、NPSは平均して10％低下しており、エンジン2のNPSがエンジン1のNPSに比べて向上している可能性も殆どない事を示しています。

実際には、benchコマンドでの探索速度が多少低下していても棋力が向上している場合もあり、探索パラメーターの調整等を伴う場合にはbenchコマンドの結果だけでは変更結果の成否を判断するのが難しい場合も多いと思われます。

ですが、探索パラメータの変更を伴わない単純な探索速度の向上を試みる変更については、2エンジン間の比較を行うことにメリットもあるかと思われます。