### PR TITLE
LearnerThink::calc_loss()内のワーカースレッドでWinProcGroup::bindThisThread()を呼び出すようにした

### DIFF
--- a/source/learn/learner.cpp
+++ b/source/learn/learner.cpp
@@ -1634,6 +1634,9 @@ void LearnerThink::calc_loss(size_t thread_id, u64 done)
 		// ↑で使っているposをcaptureされるとたまらんのでcaptureしたい変数は一つずつ指定しておく。
 		auto task = [&ps,&test_sum_cross_entropy_eval,&test_sum_cross_entropy_win,&test_sum_cross_entropy,&test_sum_entropy_eval,&test_sum_entropy_win,&test_sum_entropy, &sum_norm,&task_count ,&move_accord_count](size_t thread_id)
 		{
+			// 複数のプロセスでlearnコマンドを実行した場合、NUMAノード0しか使われなくなる問題への対処
+			WinProcGroup::bindThisThread(thread_id);
+
 			// これ、C++ではループごとに新たなpsのインスタンスをちゃんとcaptureするのだろうか.. →　するようだ。
 			auto th = Threads[thread_id];
 			auto& pos = th->rootPos;


### PR DESCRIPTION
複数のプロセスでlearnコマンドを実行した場合、NUMAノード0しか使われなくなる事に気づきました。LearnerThink::calc_loss()はスレッド並列で動いており、それらのスレッドを適切なNUMAノードに割り当てることで、ある程度緩和できると考え、LearnerThink::calc_loss()内のワーカースレッドでWinProcGroup::bindThisThread()を呼び出すようにしました。