### PR TITLE
Backport from Stockfish NNUE

### DIFF
--- a/source/eval/nnue/layers/affine_transform.h
+++ b/source/eval/nnue/layers/affine_transform.h
@@ -88,114 +88,607 @@ namespace Eval::NNUE::Layers {
       const TransformedFeatureType* transformed_features, char* buffer) const {
     const auto input = previous_layer_.Propagate(
         transformed_features, buffer + kSelfBufferSize);
+
+  #if defined (USE_AVX512)
+
+    [[maybe_unused]] const __m512i kOnes512 = _mm512_set1_epi16(1);
+
+    [[maybe_unused]] auto m512_hadd = [](__m512i sum, int bias) -> int {
+      return _mm512_reduce_add_epi32(sum) + bias;
+    };
+
+    // This function takes
+    //   sum0 = [xmm0a, xmm0b, xmm0c, xmm0d]
+    //   sum1 = [xmm1a, xmm1b, xmm1c, xmm1d]
+    //   sum2 = [xmm2a, xmm2b, xmm2c, xmm2d]
+    //   sum3 = [xmm3a, xmm3b, xmm3c, xmm3d]
+    // and returns
+    //   ret = [
+    //     reduce_add_epi32(xmm0a), reduce_add_epi32(xmm1a), reduce_add_epi32(xmm2a), reduce_add_epi32(xmm3a),
+    //     reduce_add_epi32(xmm0b), reduce_add_epi32(xmm1b), reduce_add_epi32(xmm2b), reduce_add_epi32(xmm3b),
+    //     reduce_add_epi32(xmm0c), reduce_add_epi32(xmm1c), reduce_add_epi32(xmm2c), reduce_add_epi32(xmm3c),
+    //     reduce_add_epi32(xmm0d), reduce_add_epi32(xmm1d), reduce_add_epi32(xmm2d), reduce_add_epi32(xmm3d)
+    //   ]
+    [[maybe_unused]] auto m512_hadd128x16_interleave = [](
+      __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3) -> __m512i {
+
+      __m512i sum01a = _mm512_unpacklo_epi32(sum0, sum1);
+      __m512i sum01b = _mm512_unpackhi_epi32(sum0, sum1);
+
+      __m512i sum23a = _mm512_unpacklo_epi32(sum2, sum3);
+      __m512i sum23b = _mm512_unpackhi_epi32(sum2, sum3);
+
+      __m512i sum01 = _mm512_add_epi32(sum01a, sum01b);
+      __m512i sum23 = _mm512_add_epi32(sum23a, sum23b);
+
+      __m512i sum0123a = _mm512_unpacklo_epi64(sum01, sum23);
+      __m512i sum0123b = _mm512_unpackhi_epi64(sum01, sum23);
+
+      return _mm512_add_epi32(sum0123a, sum0123b);
+    };
+
+    [[maybe_unused]] auto m512_haddx4 = [m512_hadd128x16_interleave](
+      __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3, __m128i bias) -> __m128i {
+
+      __m512i sum = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
+
+      __m256i sum256lo = _mm512_castsi512_si256(sum);
+      __m256i sum256hi = _mm512_extracti64x4_epi64(sum, 1);
+
+      sum256lo = _mm256_add_epi32(sum256lo, sum256hi);
+
+      __m128i sum128lo = _mm256_castsi256_si128(sum256lo);
+      __m128i sum128hi = _mm256_extracti128_si256(sum256lo, 1);
+
+      return _mm_add_epi32(_mm_add_epi32(sum128lo, sum128hi), bias);
+    };
+
+    [[maybe_unused]] auto m512_haddx8 = [m512_hadd128x16_interleave](
+      __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3,
+      __m512i sum4, __m512i sum5, __m512i sum6, __m512i sum7, __m256i bias) -> __m256i {
+
+      __m512i suma = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
+      __m512i sumb = m512_hadd128x16_interleave(sum4, sum5, sum6, sum7);
+
+      __m512i indices0 = _mm512_setr_epi64(0, 1, 8, 9, 4, 5, 12, 13);
+      __m512i indices1 = _mm512_setr_epi64(2, 3, 10, 11, 6, 7, 14, 15);
+      __m512i x = _mm512_add_epi32(
+          _mm512_permutex2var_epi64(suma, indices0, sumb),
+          _mm512_permutex2var_epi64(suma, indices1, sumb));
+
+      __m256i sum256lo = _mm512_castsi512_si256(x);
+      __m256i sum256hi = _mm512_extracti64x4_epi64(x, 1);
+
+      return _mm256_add_epi32(_mm256_add_epi32(sum256lo, sum256hi), bias);
+    };
+
+    [[maybe_unused]] auto m512_hadd256x8 =[m512_hadd128x16_interleave](
+      __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3, __m256i bias) -> __m256i {
+
+      __m512i sum = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
+
+      __m512i indices = _mm512_setr_epi32(
+          0, 4, 8, 12, 2, 6, 10, 14,
+          1, 5, 9, 13, 3, 7, 11, 15);
+      sum = _mm512_permutexvar_epi32(indices, sum);
+
+      __m256i sum256lo = _mm512_castsi512_si256(sum);
+      __m256i sum256hi = _mm512_extracti64x4_epi64(sum, 1);
+
+      return _mm256_add_epi32(_mm256_hadd_epi32(sum256lo, sum256hi), bias);
+    };
+
+    [[maybe_unused]] auto m512_hadd256x16 = [m512_hadd128x16_interleave](
+      __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3,
+      __m512i sum4, __m512i sum5, __m512i sum6, __m512i sum7, __m512i bias) -> __m512i {
+
+      __m512i suma = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
+      __m512i sumb = m512_hadd128x16_interleave(sum4, sum5, sum6, sum7);
+
+      __m512i indices0 = _mm512_setr_epi64(0, 1, 8, 9, 4, 5, 12, 13);
+      __m512i indices1 = _mm512_setr_epi64(2, 3, 10, 11, 6, 7, 14, 15);
+      __m512i x = _mm512_add_epi32(
+        _mm512_permutex2var_epi64(suma, indices0, sumb),
+        _mm512_permutex2var_epi64(suma, indices1, sumb));
+
+      __m512i indices = _mm512_setr_epi32(0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15);
+      return _mm512_add_epi32(_mm512_permutexvar_epi32(indices, x), bias);
+    };
+
+  #if defined (USE_VNNI)
+    [[maybe_unused]] auto m512_add_dpbusd_epi32 = [=](__m512i& acc, __m512i a, __m512i b) {
+      acc = _mm512_dpbusd_epi32(acc, a, b);
+  #else
+    [[maybe_unused]] auto m512_dpbusd_epi32 = [=](__m512i a, __m512i b) -> __m512i {
+      __m512i product0 = _mm512_maddubs_epi16(a, b);
+      return _mm512_madd_epi16(product0, kOnes512);
+  #endif
+    };
+
+  #endif
+  #if defined (USE_AVX2)
+
+    [[maybe_unused]] const __m256i kOnes256 = _mm256_set1_epi16(1);
+
+    [[maybe_unused]] auto m256_hadd = [](__m256i sum, int bias) -> int {
+      __m128i sum128 = _mm_add_epi32(_mm256_castsi256_si128(sum), _mm256_extracti128_si256(sum, 1));
+      sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_BADC));
+      sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_CDAB));
+      return _mm_cvtsi128_si32(sum128) + bias;
+    };
+
+    [[maybe_unused]] auto m256_haddx4 = [](__m256i sum0, __m256i sum1, __m256i sum2, __m256i sum3, __m128i bias) -> __m128i {
+      sum0 = _mm256_hadd_epi32(sum0, sum1);
+      sum2 = _mm256_hadd_epi32(sum2, sum3);
+
+      sum0 = _mm256_hadd_epi32(sum0, sum2);
+
+      __m128i sum128lo = _mm256_castsi256_si128(sum0);
+      __m128i sum128hi = _mm256_extracti128_si256(sum0, 1);
+
+      return _mm_add_epi32(_mm_add_epi32(sum128lo, sum128hi), bias);
+    };
+  #if defined (USE_VNNI)
+    [[maybe_unused]] auto m256_add_dpbusd_epi32 = [=](__m256i& acc, __m256i a, __m256i b) {
+      acc = _mm256_dpbusd_epi32(acc, a, b);
+  #else
+    [[maybe_unused]] auto m256_dpbusd_epi32 = [=](__m256i a, __m256i b) -> __m256i {
+      __m256i product0 = _mm256_maddubs_epi16(a, b);
+      return _mm256_madd_epi16(product0, kOnes256);
+  #endif
+    };
+
+  #endif
+
+  #if defined (USE_SSSE3)
+
+    [[maybe_unused]] const __m128i kOnes128 = _mm_set1_epi16(1);
+
+    [[maybe_unused]] auto m128_hadd = [](__m128i sum, int bias) -> int {
+      sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4E)); //_MM_PERM_BADC
+      sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xB1)); //_MM_PERM_CDAB
+      return _mm_cvtsi128_si32(sum) + bias;
+    };
+
+    [[maybe_unused]] auto m128_haddx4 = [](__m128i sum0, __m128i sum1, __m128i sum2, __m128i sum3, __m128i bias) -> __m128i {
+      sum0 = _mm_hadd_epi32(sum0, sum1);
+      sum2 = _mm_hadd_epi32(sum2, sum3);
+
+      sum0 = _mm_hadd_epi32(sum0, sum2);
+
+      return _mm_add_epi32(sum0, bias);
+    };
+
+    [[maybe_unused]] auto m128_dpbusd_epi32 = [=](__m128i a, __m128i b) -> __m128i {
+      __m128i product0 = _mm_maddubs_epi16(a, b);
+      return _mm_madd_epi16(product0, kOnes128);
+    };
+
+  #endif
+
+  #if defined (USE_AVX512)
+
+    constexpr IndexType kNumChunks512 = kPaddedInputDimensions / (kSimdWidth * 2);
+    constexpr IndexType kNumChunks256 = kPaddedInputDimensions / kSimdWidth;
+
     const auto output = reinterpret_cast<OutputType*>(buffer);
 
-  #if defined(USE_AVX512)
-        constexpr IndexType kNumChunks = kPaddedInputDimensions / (kSimdWidth * 2);
-        const auto input_vector = reinterpret_cast<const __m512i*>(input);
-  #if !defined(USE_VNNI)
-        const __m512i kOnes = _mm512_set1_epi16(1);
-  #endif
+    // Since to saturate a zmm register it takes 64 bytes we
+    // cannot use AVX512 for the smaller affine transforms.
+    // Instead we fallback to a AVX2 implementation if the
+    // kInputDimensions isn't a multiple of 64.
+    // Note that this means that for example for
+    // kInputDimensions of 96 we fallback to AVX2 even though
+    // the first 64 elements could be processed with AVX512.
+    // This is caused by mixing the __m256 and __m512 variables
+    // required to better handle that case and it would
+    // require handling more cases statically not to lose performance.
+    // This should be revisited if such input dimensions are to be considered.
+    [[maybe_unused]] const auto input_vector512 = reinterpret_cast<const __m512i*>(input);
+    [[maybe_unused]] const auto input_vector256 = reinterpret_cast<const __m256i*>(input);
 
-  #elif defined(USE_AVX2)
-    constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-        const auto input_vector = reinterpret_cast<const __m256i*>(input);
-  #if !defined(USE_VNNI)
-    const __m256i kOnes = _mm256_set1_epi16(1);
-  #endif
+    // kOutputDimensions is either 1 or a multiple of kSimdWidth
+    // because then it is also an input dimension.
+    if constexpr (kOutputDimensions % 16 == 0 && kNumChunks256 == 1)
+    {
+      for (IndexType i = 0; i < kOutputDimensions; i += 16)
+      {
+        const IndexType offset01a = (i + 0) * kPaddedInputDimensions;
+        const IndexType offset23a = (i + 2) * kPaddedInputDimensions;
+        const IndexType offset45a = (i + 4) * kPaddedInputDimensions;
+        const IndexType offset67a = (i + 6) * kPaddedInputDimensions;
+        const IndexType offset01b = (i + 8) * kPaddedInputDimensions;
+        const IndexType offset23b = (i + 10) * kPaddedInputDimensions;
+        const IndexType offset45b = (i + 12) * kPaddedInputDimensions;
+        const IndexType offset67b = (i + 14) * kPaddedInputDimensions;
 
-  #elif defined(USE_SSE2)
-    constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-  #ifndef USE_SSSE3
-        const __m128i kZeros = _mm_setzero_si128();
+        const __m512i bias = *reinterpret_cast<const __m512i*>(&biases_[i]);
+        __m512i* outptr = reinterpret_cast<__m512i*>(&output[i]);
+
+        const auto row01a = *reinterpret_cast<const __m512i*>(&weights_[offset01a]);
+        const auto row23a = *reinterpret_cast<const __m512i*>(&weights_[offset23a]);
+        const auto row45a = *reinterpret_cast<const __m512i*>(&weights_[offset45a]);
+        const auto row67a = *reinterpret_cast<const __m512i*>(&weights_[offset67a]);
+        const auto row01b = *reinterpret_cast<const __m512i*>(&weights_[offset01b]);
+        const auto row23b = *reinterpret_cast<const __m512i*>(&weights_[offset23b]);
+        const auto row45b = *reinterpret_cast<const __m512i*>(&weights_[offset45b]);
+        const auto row67b = *reinterpret_cast<const __m512i*>(&weights_[offset67b]);
+
+        const __m256i in256 = input_vector256[0];
+        const __m512i in = _mm512_inserti64x4(_mm512_castsi256_si512(in256), in256, 1);
+
+  #if defined (USE_VNNI)
+        __m512i sum01a = _mm512_setzero_si512();
+        __m512i sum23a = _mm512_setzero_si512();
+        __m512i sum45a = _mm512_setzero_si512();
+        __m512i sum67a = _mm512_setzero_si512();
+        __m512i sum01b = _mm512_setzero_si512();
+        __m512i sum23b = _mm512_setzero_si512();
+        __m512i sum45b = _mm512_setzero_si512();
+        __m512i sum67b = _mm512_setzero_si512();
+
+        m512_add_dpbusd_epi32(sum01a, in, row01a);
+        m512_add_dpbusd_epi32(sum23a, in, row23a);
+        m512_add_dpbusd_epi32(sum45a, in, row45a);
+        m512_add_dpbusd_epi32(sum67a, in, row67a);
+        m512_add_dpbusd_epi32(sum01b, in, row01b);
+        m512_add_dpbusd_epi32(sum23b, in, row23b);
+        m512_add_dpbusd_epi32(sum45b, in, row45b);
+        m512_add_dpbusd_epi32(sum67b, in, row67b);
   #else
-    const __m128i kOnes = _mm_set1_epi16(1);
+        __m512i sum01a = m512_dpbusd_epi32(in, row01a);
+        __m512i sum23a = m512_dpbusd_epi32(in, row23a);
+        __m512i sum45a = m512_dpbusd_epi32(in, row45a);
+        __m512i sum67a = m512_dpbusd_epi32(in, row67a);
+        __m512i sum01b = m512_dpbusd_epi32(in, row01b);
+        __m512i sum23b = m512_dpbusd_epi32(in, row23b);
+        __m512i sum45b = m512_dpbusd_epi32(in, row45b);
+        __m512i sum67b = m512_dpbusd_epi32(in, row67b);
   #endif
+
+        *outptr = m512_hadd256x16(
+            sum01a, sum23a, sum45a, sum67a,
+            sum01b, sum23b, sum45b, sum67b, bias);
+      }
+    }
+    else if constexpr (kOutputDimensions % 4 == 0)
+    {
+      for (IndexType i = 0; i < kOutputDimensions; i += 4)
+      {
+        const IndexType offset0 = (i + 0) * kPaddedInputDimensions;
+        const IndexType offset1 = (i + 1) * kPaddedInputDimensions;
+        const IndexType offset2 = (i + 2) * kPaddedInputDimensions;
+        const IndexType offset3 = (i + 3) * kPaddedInputDimensions;
+
+        const __m128i bias = *reinterpret_cast<const __m128i*>(&biases_[i]);
+        __m128i* outptr = reinterpret_cast<__m128i*>(&output[i]);
+
+        if constexpr (kPaddedInputDimensions % (kSimdWidth * 2) == 0)
+        {
+          const auto row0 = reinterpret_cast<const __m512i*>(&weights_[offset0]);
+          const auto row1 = reinterpret_cast<const __m512i*>(&weights_[offset1]);
+          const auto row2 = reinterpret_cast<const __m512i*>(&weights_[offset2]);
+          const auto row3 = reinterpret_cast<const __m512i*>(&weights_[offset3]);
+
+  #if defined (USE_VNNI)
+          __m512i sum0 = _mm512_setzero_si512();
+          __m512i sum1 = _mm512_setzero_si512();
+          __m512i sum2 = _mm512_setzero_si512();
+          __m512i sum3 = _mm512_setzero_si512();
+          const IndexType kStart = 0;
+  #else
+          __m512i sum0 = m512_dpbusd_epi32(input_vector512[0], row0[0]);
+          __m512i sum1 = m512_dpbusd_epi32(input_vector512[0], row1[0]);
+          __m512i sum2 = m512_dpbusd_epi32(input_vector512[0], row2[0]);
+          __m512i sum3 = m512_dpbusd_epi32(input_vector512[0], row3[0]);
+          const IndexType kStart = 1;
+  #endif
+
+          for (IndexType j = kStart; j < kNumChunks512; ++j)
+          {
+            const __m512i in = input_vector512[j];
+
+  #if defined (USE_VNNI)
+            m512_add_dpbusd_epi32(sum0, in, row0[j]);
+            m512_add_dpbusd_epi32(sum1, in, row1[j]);
+            m512_add_dpbusd_epi32(sum2, in, row2[j]);
+            m512_add_dpbusd_epi32(sum3, in, row3[j]);
+  #else
+            sum0 = _mm512_add_epi32(sum0, m512_dpbusd_epi32(in, row0[j]));
+            sum1 = _mm512_add_epi32(sum1, m512_dpbusd_epi32(in, row1[j]));
+            sum2 = _mm512_add_epi32(sum2, m512_dpbusd_epi32(in, row2[j]));
+            sum3 = _mm512_add_epi32(sum3, m512_dpbusd_epi32(in, row3[j]));
+  #endif
+          }
+
+          *outptr = m512_haddx4(sum0, sum1, sum2, sum3, bias);
+        }
+        else
+        {
+          const auto row0 = reinterpret_cast<const __m256i*>(&weights_[offset0]);
+          const auto row1 = reinterpret_cast<const __m256i*>(&weights_[offset1]);
+          const auto row2 = reinterpret_cast<const __m256i*>(&weights_[offset2]);
+          const auto row3 = reinterpret_cast<const __m256i*>(&weights_[offset3]);
+
+  #if defined (USE_VNNI)
+          __m256i sum0 = _mm256_setzero_si256();
+          __m256i sum1 = _mm256_setzero_si256();
+          __m256i sum2 = _mm256_setzero_si256();
+          __m256i sum3 = _mm256_setzero_si256();
+          const IndexType kStart = 0;
+  #else
+          __m256i sum0 = m256_dpbusd_epi32(input_vector256[0], row0[0]);
+          __m256i sum1 = m256_dpbusd_epi32(input_vector256[0], row1[0]);
+          __m256i sum2 = m256_dpbusd_epi32(input_vector256[0], row2[0]);
+          __m256i sum3 = m256_dpbusd_epi32(input_vector256[0], row3[0]);
+          const IndexType kStart = 1;
+  #endif
+
+          for (IndexType j = kStart; j < kNumChunks256; ++j)
+          {
+            const __m256i in = input_vector256[j];
+
+  #if defined (USE_VNNI)
+            m256_add_dpbusd_epi32(sum0, in, row0[j]);
+            m256_add_dpbusd_epi32(sum1, in, row1[j]);
+            m256_add_dpbusd_epi32(sum2, in, row2[j]);
+            m256_add_dpbusd_epi32(sum3, in, row3[j]);
+  #else
+            sum0 = _mm256_add_epi32(sum0, m256_dpbusd_epi32(in, row0[j]));
+            sum1 = _mm256_add_epi32(sum1, m256_dpbusd_epi32(in, row1[j]));
+            sum2 = _mm256_add_epi32(sum2, m256_dpbusd_epi32(in, row2[j]));
+            sum3 = _mm256_add_epi32(sum3, m256_dpbusd_epi32(in, row3[j]));
+  #endif
+          }
+
+          *outptr = m256_haddx4(sum0, sum1, sum2, sum3, bias);
+        }
+      }
+    }
+    else if constexpr (kOutputDimensions == 1)
+    {
+      if constexpr (kPaddedInputDimensions % (kSimdWidth * 2) == 0)
+      {
+        const auto row0 = reinterpret_cast<const __m512i*>(&weights_[0]);
+
+  #if defined (USE_VNNI)
+        __m512i sum0 = _mm512_setzero_si512();
+        const IndexType kStart = 0;
+  #else
+        __m512i sum0 = m512_dpbusd_epi32(input_vector512[0], row0[0]);
+        const IndexType kStart = 1;
+  #endif
+
+        for (IndexType j = kStart; j < kNumChunks512; ++j)
+        {
+          const __m512i in = input_vector512[j];
+
+  #if defined (USE_VNNI)
+          m512_add_dpbusd_epi32(sum0, in, row0[j]);
+  #else
+          sum0 = _mm512_add_epi32(sum0, m512_dpbusd_epi32(in, row0[j]));
+  #endif
+        }
+
+        output[0] = m512_hadd(sum0, biases_[0]);
+      }
+      else
+      {
+        const auto row0 = reinterpret_cast<const __m256i*>(&weights_[0]);
+
+  #if defined (USE_VNNI)
+        __m256i sum0 = _mm256_setzero_si256();
+        const IndexType kStart = 0;
+  #else
+        __m256i sum0 = m256_dpbusd_epi32(input_vector256[0], row0[0]);
+        const IndexType kStart = 1;
+  #endif
+
+        for (IndexType j = kStart; j < kNumChunks256; ++j)
+        {
+          const __m256i in = input_vector256[j];
+
+  #if defined (USE_VNNI)
+          m256_add_dpbusd_epi32(sum0, in, row0[j]);
+  #else
+          sum0 = _mm256_add_epi32(sum0, m256_dpbusd_epi32(in, row0[j]));
+  #endif
+        }
+
+        output[0] = m256_hadd(sum0, biases_[0]);
+      }
+    }
+    else
+    {
+      // This case can never happen because kOutputDimensions
+      // is always 1 or a multiple of kSimdWidth.
+      ASSERT_LV5(false);
+    }
+
+  #elif defined (USE_AVX2)
+
+    constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
+
+    const auto output = reinterpret_cast<OutputType*>(buffer);
+    const auto input_vector = reinterpret_cast<const __m256i*>(input);
+
+    // kOutputDimensions is either 1 or a multiple of kSimdWidth
+    // because then it is also an input dimension.
+    if constexpr (kOutputDimensions % 4 == 0)
+    {
+      for (IndexType i = 0; i < kOutputDimensions; i += 4)
+      {
+        const IndexType offset0 = (i + 0) * kPaddedInputDimensions;
+        const IndexType offset1 = (i + 1) * kPaddedInputDimensions;
+        const IndexType offset2 = (i + 2) * kPaddedInputDimensions;
+        const IndexType offset3 = (i + 3) * kPaddedInputDimensions;
+
+        const __m128i bias = *reinterpret_cast<const __m128i*>(&biases_[i]);
+        __m128i* outptr = reinterpret_cast<__m128i*>(&output[i]);
+
+        const auto row0 = reinterpret_cast<const __m256i*>(&weights_[offset0]);
+        const auto row1 = reinterpret_cast<const __m256i*>(&weights_[offset1]);
+        const auto row2 = reinterpret_cast<const __m256i*>(&weights_[offset2]);
+        const auto row3 = reinterpret_cast<const __m256i*>(&weights_[offset3]);
+
+  #if defined (USE_VNNI)
+        __m256i sum0 = _mm256_setzero_si256();
+        __m256i sum1 = _mm256_setzero_si256();
+        __m256i sum2 = _mm256_setzero_si256();
+        __m256i sum3 = _mm256_setzero_si256();
+        const IndexType kStart = 0;
+  #else
+        __m256i sum0 = m256_dpbusd_epi32(input_vector[0], row0[0]);
+        __m256i sum1 = m256_dpbusd_epi32(input_vector[0], row1[0]);
+        __m256i sum2 = m256_dpbusd_epi32(input_vector[0], row2[0]);
+        __m256i sum3 = m256_dpbusd_epi32(input_vector[0], row3[0]);
+        const IndexType kStart = 1;
+  #endif
+
+        for (IndexType j = kStart; j < kNumChunks; ++j)
+        {
+          const __m256i in = input_vector[j];
+
+  #if defined (USE_VNNI)
+          m256_add_dpbusd_epi32(sum0, in, row0[j]);
+          m256_add_dpbusd_epi32(sum1, in, row1[j]);
+          m256_add_dpbusd_epi32(sum2, in, row2[j]);
+          m256_add_dpbusd_epi32(sum3, in, row3[j]);
+  #else
+          sum0 = _mm256_add_epi32(sum0, m256_dpbusd_epi32(in, row0[j]));
+          sum1 = _mm256_add_epi32(sum1, m256_dpbusd_epi32(in, row1[j]));
+          sum2 = _mm256_add_epi32(sum2, m256_dpbusd_epi32(in, row2[j]));
+          sum3 = _mm256_add_epi32(sum3, m256_dpbusd_epi32(in, row3[j]));
+  #endif
+        }
+
+        *outptr = m256_haddx4(sum0, sum1, sum2, sum3, bias);
+      }
+    }
+    else if constexpr (kOutputDimensions == 1)
+    {
+      const auto row0 = reinterpret_cast<const __m256i*>(&weights_[0]);
+
+  #if defined (USE_VNNI)
+      __m256i sum0 = _mm256_setzero_si256();
+      const IndexType kStart = 0;
+  #else
+      __m256i sum0 = m256_dpbusd_epi32(input_vector[0], row0[0]);
+      const IndexType kStart = 1;
+  #endif
+
+      for (IndexType j = kStart; j < kNumChunks; ++j)
+      {
+        const __m256i in = input_vector[j];
+
+  #if defined (USE_VNNI)
+        m256_add_dpbusd_epi32(sum0, in, row0[j]);
+  #else
+        sum0 = _mm256_add_epi32(sum0, m256_dpbusd_epi32(in, row0[j]));
+  #endif
+      }
+
+      output[0] = m256_hadd(sum0, biases_[0]);
+    }
+    else
+    {
+      // This case can never happen because kOutputDimensions
+      // is always 1 or a multiple of kSimdWidth.
+      ASSERT_LV5(false);
+    }
+
+  #elif defined (USE_SSSE3)
+
+    constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
+
+    auto output = reinterpret_cast<OutputType*>(buffer);
     const auto input_vector = reinterpret_cast<const __m128i*>(input);
 
+    // kOutputDimensions is either 1 or a multiple of kSimdWidth
+    // because then it is also an input dimension.
+    if constexpr (kOutputDimensions % 4 == 0)
+    {
+      for (IndexType i = 0; i < kOutputDimensions; i += 4)
+      {
+        const IndexType offset0 = (i + 0) * kPaddedInputDimensions;
+        const IndexType offset1 = (i + 1) * kPaddedInputDimensions;
+        const IndexType offset2 = (i + 2) * kPaddedInputDimensions;
+        const IndexType offset3 = (i + 3) * kPaddedInputDimensions;
+
+        const __m128i bias = *reinterpret_cast<const __m128i*>(&biases_[i]);
+        __m128i* outptr = reinterpret_cast<__m128i*>(&output[i]);
+
+        const auto row0 = reinterpret_cast<const __m128i*>(&weights_[offset0]);
+        const auto row1 = reinterpret_cast<const __m128i*>(&weights_[offset1]);
+        const auto row2 = reinterpret_cast<const __m128i*>(&weights_[offset2]);
+        const auto row3 = reinterpret_cast<const __m128i*>(&weights_[offset3]);
+
+          __m128i sum0 = m128_dpbusd_epi32(input_vector[0], row0[0]);
+          __m128i sum1 = m128_dpbusd_epi32(input_vector[0], row1[0]);
+          __m128i sum2 = m128_dpbusd_epi32(input_vector[0], row2[0]);
+          __m128i sum3 = m128_dpbusd_epi32(input_vector[0], row3[0]);
+
+          for (int j = 1; j < (int)kNumChunks; ++j)
+          {
+            const __m128i in = input_vector[j];
+
+            sum0 = _mm_add_epi32(sum0, m128_dpbusd_epi32(in, row0[j]));
+            sum1 = _mm_add_epi32(sum1, m128_dpbusd_epi32(in, row1[j]));
+            sum2 = _mm_add_epi32(sum2, m128_dpbusd_epi32(in, row2[j]));
+            sum3 = _mm_add_epi32(sum3, m128_dpbusd_epi32(in, row3[j]));
+          }
+
+          *outptr = m128_haddx4(sum0, sum1, sum2, sum3, bias);
+        }
+      }
+      else if constexpr (kOutputDimensions == 1)
+      {
+        const auto row0 = reinterpret_cast<const __m128i*>(&weights_[0]);
+
+        __m128i sum0 = m128_dpbusd_epi32(input_vector[0], row0[0]);
+
+        for (int j = 1; j < (int)kNumChunks; ++j) {
+          sum0 = _mm_add_epi32(sum0, m128_dpbusd_epi32(input_vector[j], row0[j]));
+        }
+
+        output[0] = m128_hadd(sum0, biases_[0]);
+      }
+      else
+      {
+          // This case can never happen because kOutputDimensions
+          // is always 1 or a multiple of kSimdWidth.
+          ASSERT_LV5(false);
+      }
+
+  #else  // if not defined (USE_AVX512|USE_AVX2|USE_SSSE3)
+
+  // Use old implementation for the other architectures.
+
+      auto output = reinterpret_cast<OutputType*>(buffer);
+
+  #if defined(USE_SSE2)
+          constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
+  #ifndef USE_SSSE3
+          const __m128i kZeros = _mm_setzero_si128();
+  #else
+          const __m128i kOnes = _mm_set1_epi16(1);
+  #endif
+          const auto input_vector = reinterpret_cast<const __m128i*>(input);
+
   #elif defined(USE_MMX)
-        constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-        const __m64 kZeros = _mm_setzero_si64();
-        const auto input_vector = reinterpret_cast<const __m64*>(input);
+          constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
+          const __m64 kZeros = _mm_setzero_si64();
+          const auto input_vector = reinterpret_cast<const __m64*>(input);
 
   #elif defined(USE_NEON)
-    constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-    const auto input_vector = reinterpret_cast<const int8x8_t*>(input);
-
+          constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
+          const auto input_vector = reinterpret_cast<const int8x8_t*>(input);
   #endif
 
-    for (IndexType i = 0; i < kOutputDimensions; ++i) {
-      const IndexType offset = i * kPaddedInputDimensions;
+          for (IndexType i = 0; i < kOutputDimensions; ++i) {
+            const IndexType offset = i * kPaddedInputDimensions;
 
-  #if defined(USE_AVX512)
-            __m512i sum = _mm512_setzero_si512();
-            const auto row = reinterpret_cast<const __m512i*>(&weights_[offset]);
-            for (IndexType j = 0; j < kNumChunks; ++j) {
-  #if defined(USE_VNNI)
-                sum = _mm512_dpbusd_epi32(sum, _mm512_loadA_si512(&input_vector[j]), _mm512_load_si512(&row[j]));
-  #else
-                __m512i product = _mm512_maddubs_epi16(_mm512_loadA_si512(&input_vector[j]), _mm512_load_si512(&row[j]));
-                product = _mm512_madd_epi16(product, kOnes);
-                sum = _mm512_add_epi32(sum, product);
-  #endif
-            }
-
-            // Note: Changing kMaxSimdWidth from 32 to 64 breaks loading existing networks.
-            // As a result kPaddedInputDimensions may not be an even multiple of 64(512bit)
-            // and we have to do one more 256bit chunk.
-            if (kPaddedInputDimensions != kNumChunks * kSimdWidth * 2)
-            {
-                const auto iv256  = reinterpret_cast<const __m256i*>(&input_vector[kNumChunks]);
-                const auto row256 = reinterpret_cast<const __m256i*>(&row[kNumChunks]);
-  #if defined(USE_VNNI)
-                __m256i product256 = _mm256_dpbusd_epi32(
-                _mm512_castsi512_si256(sum), _mm256_loadA_si256(&iv256[0]), _mm256_load_si256(&row256[0]));
-                sum = _mm512_inserti32x8(sum, product256, 0);
-  #else
-                __m256i product256 = _mm256_maddubs_epi16(_mm256_loadA_si256(&iv256[0]), _mm256_load_si256(&row256[0]));
-                sum = _mm512_add_epi32(sum, _mm512_cvtepi16_epi32(product256));
-  #endif
-            }
-            output[i] = _mm512_reduce_add_epi32(sum) + biases_[i];
-
-  #elif defined(USE_AVX2)
-            __m256i sum = _mm256_setzero_si256();
-      const auto row = reinterpret_cast<const __m256i*>(&weights_[offset]);
-      for (IndexType j = 0; j < kNumChunks; ++j) {
-  #if defined(USE_VNNI)
-                sum = _mm256_dpbusd_epi32(sum, _mm256_loadA_si256(&input_vector[j]), _mm256_load_si256(&row[j]));
-  #else
-                __m256i product = _mm256_maddubs_epi16(_mm256_loadA_si256(&input_vector[j]), _mm256_load_si256(&row[j]));
-        product = _mm256_madd_epi16(product, kOnes);
-        sum = _mm256_add_epi32(sum, product);
-  #endif
-      }
-            __m128i sum128 = _mm_add_epi32(_mm256_castsi256_si128(sum), _mm256_extracti128_si256(sum, 1));
-            sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_BADC));
-            sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_CDAB));
-            output[i] = _mm_cvtsi128_si32(sum128) + biases_[i];
-
-#elif defined(USE_SSSE3)
-            __m128i sum = _mm_setzero_si128();
-      const auto row = reinterpret_cast<const __m128i*>(&weights_[offset]);
-            for (int j = 0; j < (int)kNumChunks - 1; j += 2) {
-                __m128i product0 = _mm_maddubs_epi16(_mm_load_si128(&input_vector[j]), _mm_load_si128(&row[j]));
-                product0 = _mm_madd_epi16(product0, kOnes);
-                sum = _mm_add_epi32(sum, product0);
-                __m128i product1 = _mm_maddubs_epi16(_mm_load_si128(&input_vector[j+1]), _mm_load_si128(&row[j+1]));
-                product1 = _mm_madd_epi16(product1, kOnes);
-                sum = _mm_add_epi32(sum, product1);
-            }
-            if (kNumChunks & 0x1) {
-                __m128i product = _mm_maddubs_epi16(_mm_load_si128(&input_vector[kNumChunks-1]), _mm_load_si128(&row[kNumChunks-1]));
-        product = _mm_madd_epi16(product, kOnes);
-        sum = _mm_add_epi32(sum, product);
-      }
-            sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4E)); //_MM_PERM_BADC
-            sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xB1)); //_MM_PERM_CDAB
-            output[i] = _mm_cvtsi128_si32(sum) + biases_[i];
-
-  #elif defined(USE_SSE2)
+  #if defined(USE_SSE2)
             __m128i sum_lo = _mm_cvtsi32_si128(biases_[i]);
             __m128i sum_hi = kZeros;
             const auto row = reinterpret_cast<const __m128i*>(&weights_[offset]);
@@ -249,18 +742,23 @@ namespace Eval::NNUE::Layers {
         sum = vpadalq_s16(sum, product);
       }
       output[i] = sum[0] + sum[1] + sum[2] + sum[3];
+
   #else
-	  // CPUに依存しないコード
+      // CPUに依存しないコード
       OutputType sum = biases_[i];
       for (IndexType j = 0; j < kInputDimensions; ++j) {
         sum += weights_[offset + j] * input[j];
       }
       output[i] = sum;
   #endif
+
     }
   #if defined(USE_MMX)
-        mm_empty();
+        _mm_empty();
   #endif
+
+  #endif  // not defined (USE_AVX512|USE_AVX2|USE_SSSE3)
+
     return output;
   }
 

--- a/source/eval/nnue/layers/affine_transform.h
+++ b/source/eval/nnue/layers/affine_transform.h
@@ -12,775 +12,720 @@
 
 namespace Eval::NNUE::Layers {
 
-  // Affine transformation layer
-  // アフィン変換層
-  template <typename PreviousLayer, IndexType OutputDimensions>
-  class AffineTransform {
- public:
-   // Input/output type
-  // 入出力の型
-  using InputType = typename PreviousLayer::OutputType;
-  using OutputType = std::int32_t;
-  static_assert(std::is_same<InputType, std::uint8_t>::value, "");
-
-    // Number of input/output dimensions
-  // 入出力の次元数
-  static constexpr IndexType kInputDimensions =
-      PreviousLayer::kOutputDimensions;
-  static constexpr IndexType kOutputDimensions = OutputDimensions;
-  static constexpr IndexType kPaddedInputDimensions =
-      CeilToMultiple<IndexType>(kInputDimensions, kMaxSimdWidth);
-
-    // Size of forward propagation buffer used in this layer
-  // この層で使用する順伝播用バッファのサイズ
-  static constexpr std::size_t kSelfBufferSize =
-      CeilToMultiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
-
-    // Size of the forward propagation buffer used from the input layer to this layer
-  // 入力層からこの層までで使用する順伝播用バッファのサイズ
-  static constexpr std::size_t kBufferSize =
-      PreviousLayer::kBufferSize + kSelfBufferSize;
-
-  // 評価関数ファイルに埋め込むハッシュ値
-    // Hash value embedded in the evaluation file
-  static constexpr std::uint32_t GetHashValue() {
-    std::uint32_t hash_value = 0xCC03DAE4u;
-    hash_value += kOutputDimensions;
-    hash_value ^= PreviousLayer::GetHashValue() >> 1;
-    hash_value ^= PreviousLayer::GetHashValue() << 31;
-    return hash_value;
-  }
-
-  // 入力層からこの層までの構造を表す文字列
-  static std::string GetStructureString() {
-    return "AffineTransform[" +
-        std::to_string(kOutputDimensions) + "<-" +
-        std::to_string(kInputDimensions) + "](" +
-        PreviousLayer::GetStructureString() + ")";
-  }
-
-   // Read network parameters
-  // パラメータを読み込む
-  bool ReadParameters(std::istream& stream) {
-    if (!previous_layer_.ReadParameters(stream)) return false;
-      for (std::size_t i = 0; i < kOutputDimensions; ++i)
-        biases_[i] = read_little_endian<BiasType>(stream);
-      for (std::size_t i = 0; i < kOutputDimensions * kPaddedInputDimensions; ++i)
-        weights_[i] = read_little_endian<WeightType>(stream);
-    return !stream.fail();
-  }
-
-  // パラメータを書き込む
-  bool WriteParameters(std::ostream& stream) const {
-    if (!previous_layer_.WriteParameters(stream)) return false;
-    // TODO : endiannessの調整するコード必要なのでは。(やね)
-    stream.write(reinterpret_cast<const char*>(biases_),
-                 kOutputDimensions * sizeof(BiasType));
-    stream.write(reinterpret_cast<const char*>(weights_),
-                 kOutputDimensions * kPaddedInputDimensions *
-                 sizeof(WeightType));
-    return !stream.fail();
-  }
-
-    // Forward propagation
-  // 順伝播
-  const OutputType* Propagate(
-      const TransformedFeatureType* transformed_features, char* buffer) const {
-    const auto input = previous_layer_.Propagate(
-        transformed_features, buffer + kSelfBufferSize);
-
-  #if defined (USE_AVX512)
-
-    [[maybe_unused]] const __m512i kOnes512 = _mm512_set1_epi16(1);
-
-    [[maybe_unused]] auto m512_hadd = [](__m512i sum, int bias) -> int {
-      return _mm512_reduce_add_epi32(sum) + bias;
-    };
-
-    // This function takes
-    //   sum0 = [xmm0a, xmm0b, xmm0c, xmm0d]
-    //   sum1 = [xmm1a, xmm1b, xmm1c, xmm1d]
-    //   sum2 = [xmm2a, xmm2b, xmm2c, xmm2d]
-    //   sum3 = [xmm3a, xmm3b, xmm3c, xmm3d]
-    // and returns
-    //   ret = [
-    //     reduce_add_epi32(xmm0a), reduce_add_epi32(xmm1a), reduce_add_epi32(xmm2a), reduce_add_epi32(xmm3a),
-    //     reduce_add_epi32(xmm0b), reduce_add_epi32(xmm1b), reduce_add_epi32(xmm2b), reduce_add_epi32(xmm3b),
-    //     reduce_add_epi32(xmm0c), reduce_add_epi32(xmm1c), reduce_add_epi32(xmm2c), reduce_add_epi32(xmm3c),
-    //     reduce_add_epi32(xmm0d), reduce_add_epi32(xmm1d), reduce_add_epi32(xmm2d), reduce_add_epi32(xmm3d)
-    //   ]
-    [[maybe_unused]] auto m512_hadd128x16_interleave = [](
-      __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3) -> __m512i {
-
-      __m512i sum01a = _mm512_unpacklo_epi32(sum0, sum1);
-      __m512i sum01b = _mm512_unpackhi_epi32(sum0, sum1);
+// Affine transformation layer
+// アフィン変換層
+template <typename PreviousLayer, IndexType OutputDimensions>
+class AffineTransform {
+   public:
+	// Input/output type
+	// 入出力の型
+	using InputType  = typename PreviousLayer::OutputType;
+	using OutputType = std::int32_t;
+	static_assert(std::is_same<InputType, std::uint8_t>::value, "");
+
+	// Number of input/output dimensions
+	// 入出力の次元数
+	static constexpr IndexType kInputDimensions       = PreviousLayer::kOutputDimensions;
+	static constexpr IndexType kOutputDimensions      = OutputDimensions;
+	static constexpr IndexType kPaddedInputDimensions = CeilToMultiple<IndexType>(kInputDimensions, kMaxSimdWidth);
+
+	// Size of forward propagation buffer used in this layer
+	// この層で使用する順伝播用バッファのサイズ
+	static constexpr std::size_t kSelfBufferSize =
+	    CeilToMultiple(kOutputDimensions * sizeof(OutputType), kCacheLineSize);
+
+	// Size of the forward propagation buffer used from the input layer to this layer
+	// 入力層からこの層までで使用する順伝播用バッファのサイズ
+	static constexpr std::size_t kBufferSize = PreviousLayer::kBufferSize + kSelfBufferSize;
+
+	// 評価関数ファイルに埋め込むハッシュ値
+	// Hash value embedded in the evaluation file
+	static constexpr std::uint32_t GetHashValue() {
+		std::uint32_t hash_value = 0xCC03DAE4u;
+		hash_value += kOutputDimensions;
+		hash_value ^= PreviousLayer::GetHashValue() >> 1;
+		hash_value ^= PreviousLayer::GetHashValue() << 31;
+		return hash_value;
+	}
+
+	// 入力層からこの層までの構造を表す文字列
+	static std::string GetStructureString() {
+		return "AffineTransform[" + std::to_string(kOutputDimensions) + "<-" + std::to_string(kInputDimensions) + "](" +
+		       PreviousLayer::GetStructureString() + ")";
+	}
+
+	// Read network parameters
+	// パラメータを読み込む
+	bool ReadParameters(std::istream& stream) {
+		if (!previous_layer_.ReadParameters(stream)) return false;
+		for (std::size_t i = 0; i < kOutputDimensions; ++i) biases_[i] = read_little_endian<BiasType>(stream);
+		for (std::size_t i = 0; i < kOutputDimensions * kPaddedInputDimensions; ++i)
+			weights_[i] = read_little_endian<WeightType>(stream);
+		return !stream.fail();
+	}
+
+	// パラメータを書き込む
+	bool WriteParameters(std::ostream& stream) const {
+		if (!previous_layer_.WriteParameters(stream)) return false;
+		// TODO : endiannessの調整するコード必要なのでは。(やね)
+		stream.write(reinterpret_cast<const char*>(biases_), kOutputDimensions * sizeof(BiasType));
+		stream.write(reinterpret_cast<const char*>(weights_),
+		             kOutputDimensions * kPaddedInputDimensions * sizeof(WeightType));
+		return !stream.fail();
+	}
+
+	// Forward propagation
+	// 順伝播
+	const OutputType* Propagate(const TransformedFeatureType* transformed_features, char* buffer) const {
+		const auto input = previous_layer_.Propagate(transformed_features, buffer + kSelfBufferSize);
+
+#if defined(USE_AVX512)
+
+		[[maybe_unused]] const __m512i kOnes512 = _mm512_set1_epi16(1);
+
+		[[maybe_unused]] auto m512_hadd = [](__m512i sum, int bias) -> int {
+			return _mm512_reduce_add_epi32(sum) + bias;
+		};
+
+		// This function takes
+		//   sum0 = [xmm0a, xmm0b, xmm0c, xmm0d]
+		//   sum1 = [xmm1a, xmm1b, xmm1c, xmm1d]
+		//   sum2 = [xmm2a, xmm2b, xmm2c, xmm2d]
+		//   sum3 = [xmm3a, xmm3b, xmm3c, xmm3d]
+		// and returns
+		//   ret = [
+		//     reduce_add_epi32(xmm0a), reduce_add_epi32(xmm1a), reduce_add_epi32(xmm2a), reduce_add_epi32(xmm3a),
+		//     reduce_add_epi32(xmm0b), reduce_add_epi32(xmm1b), reduce_add_epi32(xmm2b), reduce_add_epi32(xmm3b),
+		//     reduce_add_epi32(xmm0c), reduce_add_epi32(xmm1c), reduce_add_epi32(xmm2c), reduce_add_epi32(xmm3c),
+		//     reduce_add_epi32(xmm0d), reduce_add_epi32(xmm1d), reduce_add_epi32(xmm2d), reduce_add_epi32(xmm3d)
+		//   ]
+		[[maybe_unused]] auto m512_hadd128x16_interleave = [](__m512i sum0, __m512i sum1, __m512i sum2,
+		                                                      __m512i sum3) -> __m512i {
+			__m512i sum01a = _mm512_unpacklo_epi32(sum0, sum1);
+			__m512i sum01b = _mm512_unpackhi_epi32(sum0, sum1);
+
+			__m512i sum23a = _mm512_unpacklo_epi32(sum2, sum3);
+			__m512i sum23b = _mm512_unpackhi_epi32(sum2, sum3);
+
+			__m512i sum01 = _mm512_add_epi32(sum01a, sum01b);
+			__m512i sum23 = _mm512_add_epi32(sum23a, sum23b);
+
+			__m512i sum0123a = _mm512_unpacklo_epi64(sum01, sum23);
+			__m512i sum0123b = _mm512_unpackhi_epi64(sum01, sum23);
+
+			return _mm512_add_epi32(sum0123a, sum0123b);
+		};
+
+		[[maybe_unused]] auto m512_haddx4 = [m512_hadd128x16_interleave](__m512i sum0, __m512i sum1, __m512i sum2,
+		                                                                 __m512i sum3, __m128i bias) -> __m128i {
+			__m512i sum = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
+
+			__m256i sum256lo = _mm512_castsi512_si256(sum);
+			__m256i sum256hi = _mm512_extracti64x4_epi64(sum, 1);
+
+			sum256lo = _mm256_add_epi32(sum256lo, sum256hi);
 
-      __m512i sum23a = _mm512_unpacklo_epi32(sum2, sum3);
-      __m512i sum23b = _mm512_unpackhi_epi32(sum2, sum3);
+			__m128i sum128lo = _mm256_castsi256_si128(sum256lo);
+			__m128i sum128hi = _mm256_extracti128_si256(sum256lo, 1);
 
-      __m512i sum01 = _mm512_add_epi32(sum01a, sum01b);
-      __m512i sum23 = _mm512_add_epi32(sum23a, sum23b);
+			return _mm_add_epi32(_mm_add_epi32(sum128lo, sum128hi), bias);
+		};
+
+		[[maybe_unused]] auto m512_haddx8 = [m512_hadd128x16_interleave](
+		                                        __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3, __m512i sum4,
+		                                        __m512i sum5, __m512i sum6, __m512i sum7, __m256i bias) -> __m256i {
+			__m512i suma = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
+			__m512i sumb = m512_hadd128x16_interleave(sum4, sum5, sum6, sum7);
+
+			__m512i indices0 = _mm512_setr_epi64(0, 1, 8, 9, 4, 5, 12, 13);
+			__m512i indices1 = _mm512_setr_epi64(2, 3, 10, 11, 6, 7, 14, 15);
+			__m512i x        = _mm512_add_epi32(_mm512_permutex2var_epi64(suma, indices0, sumb),
+                                         _mm512_permutex2var_epi64(suma, indices1, sumb));
+
+			__m256i sum256lo = _mm512_castsi512_si256(x);
+			__m256i sum256hi = _mm512_extracti64x4_epi64(x, 1);
 
-      __m512i sum0123a = _mm512_unpacklo_epi64(sum01, sum23);
-      __m512i sum0123b = _mm512_unpackhi_epi64(sum01, sum23);
+			return _mm256_add_epi32(_mm256_add_epi32(sum256lo, sum256hi), bias);
+		};
 
-      return _mm512_add_epi32(sum0123a, sum0123b);
-    };
+		[[maybe_unused]] auto m512_hadd256x8 = [m512_hadd128x16_interleave](__m512i sum0, __m512i sum1, __m512i sum2,
+		                                                                    __m512i sum3, __m256i bias) -> __m256i {
+			__m512i sum = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
 
-    [[maybe_unused]] auto m512_haddx4 = [m512_hadd128x16_interleave](
-      __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3, __m128i bias) -> __m128i {
+			__m512i indices = _mm512_setr_epi32(0, 4, 8, 12, 2, 6, 10, 14, 1, 5, 9, 13, 3, 7, 11, 15);
+			sum             = _mm512_permutexvar_epi32(indices, sum);
 
-      __m512i sum = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
+			__m256i sum256lo = _mm512_castsi512_si256(sum);
+			__m256i sum256hi = _mm512_extracti64x4_epi64(sum, 1);
 
-      __m256i sum256lo = _mm512_castsi512_si256(sum);
-      __m256i sum256hi = _mm512_extracti64x4_epi64(sum, 1);
+			return _mm256_add_epi32(_mm256_hadd_epi32(sum256lo, sum256hi), bias);
+		};
 
-      sum256lo = _mm256_add_epi32(sum256lo, sum256hi);
-
-      __m128i sum128lo = _mm256_castsi256_si128(sum256lo);
-      __m128i sum128hi = _mm256_extracti128_si256(sum256lo, 1);
-
-      return _mm_add_epi32(_mm_add_epi32(sum128lo, sum128hi), bias);
-    };
-
-    [[maybe_unused]] auto m512_haddx8 = [m512_hadd128x16_interleave](
-      __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3,
-      __m512i sum4, __m512i sum5, __m512i sum6, __m512i sum7, __m256i bias) -> __m256i {
-
-      __m512i suma = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
-      __m512i sumb = m512_hadd128x16_interleave(sum4, sum5, sum6, sum7);
-
-      __m512i indices0 = _mm512_setr_epi64(0, 1, 8, 9, 4, 5, 12, 13);
-      __m512i indices1 = _mm512_setr_epi64(2, 3, 10, 11, 6, 7, 14, 15);
-      __m512i x = _mm512_add_epi32(
-          _mm512_permutex2var_epi64(suma, indices0, sumb),
-          _mm512_permutex2var_epi64(suma, indices1, sumb));
-
-      __m256i sum256lo = _mm512_castsi512_si256(x);
-      __m256i sum256hi = _mm512_extracti64x4_epi64(x, 1);
-
-      return _mm256_add_epi32(_mm256_add_epi32(sum256lo, sum256hi), bias);
-    };
-
-    [[maybe_unused]] auto m512_hadd256x8 =[m512_hadd128x16_interleave](
-      __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3, __m256i bias) -> __m256i {
-
-      __m512i sum = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
-
-      __m512i indices = _mm512_setr_epi32(
-          0, 4, 8, 12, 2, 6, 10, 14,
-          1, 5, 9, 13, 3, 7, 11, 15);
-      sum = _mm512_permutexvar_epi32(indices, sum);
-
-      __m256i sum256lo = _mm512_castsi512_si256(sum);
-      __m256i sum256hi = _mm512_extracti64x4_epi64(sum, 1);
-
-      return _mm256_add_epi32(_mm256_hadd_epi32(sum256lo, sum256hi), bias);
-    };
-
-    [[maybe_unused]] auto m512_hadd256x16 = [m512_hadd128x16_interleave](
-      __m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3,
-      __m512i sum4, __m512i sum5, __m512i sum6, __m512i sum7, __m512i bias) -> __m512i {
-
-      __m512i suma = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
-      __m512i sumb = m512_hadd128x16_interleave(sum4, sum5, sum6, sum7);
-
-      __m512i indices0 = _mm512_setr_epi64(0, 1, 8, 9, 4, 5, 12, 13);
-      __m512i indices1 = _mm512_setr_epi64(2, 3, 10, 11, 6, 7, 14, 15);
-      __m512i x = _mm512_add_epi32(
-        _mm512_permutex2var_epi64(suma, indices0, sumb),
-        _mm512_permutex2var_epi64(suma, indices1, sumb));
-
-      __m512i indices = _mm512_setr_epi32(0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15);
-      return _mm512_add_epi32(_mm512_permutexvar_epi32(indices, x), bias);
-    };
-
-  #if defined (USE_VNNI)
-    [[maybe_unused]] auto m512_add_dpbusd_epi32 = [=](__m512i& acc, __m512i a, __m512i b) {
-      acc = _mm512_dpbusd_epi32(acc, a, b);
-  #else
-    [[maybe_unused]] auto m512_dpbusd_epi32 = [=](__m512i a, __m512i b) -> __m512i {
-      __m512i product0 = _mm512_maddubs_epi16(a, b);
-      return _mm512_madd_epi16(product0, kOnes512);
-  #endif
-    };
-
-  #endif
-  #if defined (USE_AVX2)
-
-    [[maybe_unused]] const __m256i kOnes256 = _mm256_set1_epi16(1);
-
-    [[maybe_unused]] auto m256_hadd = [](__m256i sum, int bias) -> int {
-      __m128i sum128 = _mm_add_epi32(_mm256_castsi256_si128(sum), _mm256_extracti128_si256(sum, 1));
-      sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_BADC));
-      sum128 = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_CDAB));
-      return _mm_cvtsi128_si32(sum128) + bias;
-    };
-
-    [[maybe_unused]] auto m256_haddx4 = [](__m256i sum0, __m256i sum1, __m256i sum2, __m256i sum3, __m128i bias) -> __m128i {
-      sum0 = _mm256_hadd_epi32(sum0, sum1);
-      sum2 = _mm256_hadd_epi32(sum2, sum3);
-
-      sum0 = _mm256_hadd_epi32(sum0, sum2);
-
-      __m128i sum128lo = _mm256_castsi256_si128(sum0);
-      __m128i sum128hi = _mm256_extracti128_si256(sum0, 1);
-
-      return _mm_add_epi32(_mm_add_epi32(sum128lo, sum128hi), bias);
-    };
-  #if defined (USE_VNNI)
-    [[maybe_unused]] auto m256_add_dpbusd_epi32 = [=](__m256i& acc, __m256i a, __m256i b) {
-      acc = _mm256_dpbusd_epi32(acc, a, b);
-  #else
-    [[maybe_unused]] auto m256_dpbusd_epi32 = [=](__m256i a, __m256i b) -> __m256i {
-      __m256i product0 = _mm256_maddubs_epi16(a, b);
-      return _mm256_madd_epi16(product0, kOnes256);
-  #endif
-    };
-
-  #endif
-
-  #if defined (USE_SSSE3)
-
-    [[maybe_unused]] const __m128i kOnes128 = _mm_set1_epi16(1);
-
-    [[maybe_unused]] auto m128_hadd = [](__m128i sum, int bias) -> int {
-      sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4E)); //_MM_PERM_BADC
-      sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xB1)); //_MM_PERM_CDAB
-      return _mm_cvtsi128_si32(sum) + bias;
-    };
-
-    [[maybe_unused]] auto m128_haddx4 = [](__m128i sum0, __m128i sum1, __m128i sum2, __m128i sum3, __m128i bias) -> __m128i {
-      sum0 = _mm_hadd_epi32(sum0, sum1);
-      sum2 = _mm_hadd_epi32(sum2, sum3);
-
-      sum0 = _mm_hadd_epi32(sum0, sum2);
-
-      return _mm_add_epi32(sum0, bias);
-    };
-
-    [[maybe_unused]] auto m128_dpbusd_epi32 = [=](__m128i a, __m128i b) -> __m128i {
-      __m128i product0 = _mm_maddubs_epi16(a, b);
-      return _mm_madd_epi16(product0, kOnes128);
-    };
-
-  #endif
-
-  #if defined (USE_AVX512)
-
-    constexpr IndexType kNumChunks512 = kPaddedInputDimensions / (kSimdWidth * 2);
-    constexpr IndexType kNumChunks256 = kPaddedInputDimensions / kSimdWidth;
-
-    const auto output = reinterpret_cast<OutputType*>(buffer);
-
-    // Since to saturate a zmm register it takes 64 bytes we
-    // cannot use AVX512 for the smaller affine transforms.
-    // Instead we fallback to a AVX2 implementation if the
-    // kInputDimensions isn't a multiple of 64.
-    // Note that this means that for example for
-    // kInputDimensions of 96 we fallback to AVX2 even though
-    // the first 64 elements could be processed with AVX512.
-    // This is caused by mixing the __m256 and __m512 variables
-    // required to better handle that case and it would
-    // require handling more cases statically not to lose performance.
-    // This should be revisited if such input dimensions are to be considered.
-    [[maybe_unused]] const auto input_vector512 = reinterpret_cast<const __m512i*>(input);
-    [[maybe_unused]] const auto input_vector256 = reinterpret_cast<const __m256i*>(input);
-
-    // kOutputDimensions is either 1 or a multiple of kSimdWidth
-    // because then it is also an input dimension.
-    if constexpr (kOutputDimensions % 16 == 0 && kNumChunks256 == 1)
-    {
-      for (IndexType i = 0; i < kOutputDimensions; i += 16)
-      {
-        const IndexType offset01a = (i + 0) * kPaddedInputDimensions;
-        const IndexType offset23a = (i + 2) * kPaddedInputDimensions;
-        const IndexType offset45a = (i + 4) * kPaddedInputDimensions;
-        const IndexType offset67a = (i + 6) * kPaddedInputDimensions;
-        const IndexType offset01b = (i + 8) * kPaddedInputDimensions;
-        const IndexType offset23b = (i + 10) * kPaddedInputDimensions;
-        const IndexType offset45b = (i + 12) * kPaddedInputDimensions;
-        const IndexType offset67b = (i + 14) * kPaddedInputDimensions;
-
-        const __m512i bias = *reinterpret_cast<const __m512i*>(&biases_[i]);
-        __m512i* outptr = reinterpret_cast<__m512i*>(&output[i]);
-
-        const auto row01a = *reinterpret_cast<const __m512i*>(&weights_[offset01a]);
-        const auto row23a = *reinterpret_cast<const __m512i*>(&weights_[offset23a]);
-        const auto row45a = *reinterpret_cast<const __m512i*>(&weights_[offset45a]);
-        const auto row67a = *reinterpret_cast<const __m512i*>(&weights_[offset67a]);
-        const auto row01b = *reinterpret_cast<const __m512i*>(&weights_[offset01b]);
-        const auto row23b = *reinterpret_cast<const __m512i*>(&weights_[offset23b]);
-        const auto row45b = *reinterpret_cast<const __m512i*>(&weights_[offset45b]);
-        const auto row67b = *reinterpret_cast<const __m512i*>(&weights_[offset67b]);
-
-        const __m256i in256 = input_vector256[0];
-        const __m512i in = _mm512_inserti64x4(_mm512_castsi256_si512(in256), in256, 1);
-
-  #if defined (USE_VNNI)
-        __m512i sum01a = _mm512_setzero_si512();
-        __m512i sum23a = _mm512_setzero_si512();
-        __m512i sum45a = _mm512_setzero_si512();
-        __m512i sum67a = _mm512_setzero_si512();
-        __m512i sum01b = _mm512_setzero_si512();
-        __m512i sum23b = _mm512_setzero_si512();
-        __m512i sum45b = _mm512_setzero_si512();
-        __m512i sum67b = _mm512_setzero_si512();
-
-        m512_add_dpbusd_epi32(sum01a, in, row01a);
-        m512_add_dpbusd_epi32(sum23a, in, row23a);
-        m512_add_dpbusd_epi32(sum45a, in, row45a);
-        m512_add_dpbusd_epi32(sum67a, in, row67a);
-        m512_add_dpbusd_epi32(sum01b, in, row01b);
-        m512_add_dpbusd_epi32(sum23b, in, row23b);
-        m512_add_dpbusd_epi32(sum45b, in, row45b);
-        m512_add_dpbusd_epi32(sum67b, in, row67b);
-  #else
-        __m512i sum01a = m512_dpbusd_epi32(in, row01a);
-        __m512i sum23a = m512_dpbusd_epi32(in, row23a);
-        __m512i sum45a = m512_dpbusd_epi32(in, row45a);
-        __m512i sum67a = m512_dpbusd_epi32(in, row67a);
-        __m512i sum01b = m512_dpbusd_epi32(in, row01b);
-        __m512i sum23b = m512_dpbusd_epi32(in, row23b);
-        __m512i sum45b = m512_dpbusd_epi32(in, row45b);
-        __m512i sum67b = m512_dpbusd_epi32(in, row67b);
-  #endif
-
-        *outptr = m512_hadd256x16(
-            sum01a, sum23a, sum45a, sum67a,
-            sum01b, sum23b, sum45b, sum67b, bias);
-      }
-    }
-    else if constexpr (kOutputDimensions % 4 == 0)
-    {
-      for (IndexType i = 0; i < kOutputDimensions; i += 4)
-      {
-        const IndexType offset0 = (i + 0) * kPaddedInputDimensions;
-        const IndexType offset1 = (i + 1) * kPaddedInputDimensions;
-        const IndexType offset2 = (i + 2) * kPaddedInputDimensions;
-        const IndexType offset3 = (i + 3) * kPaddedInputDimensions;
-
-        const __m128i bias = *reinterpret_cast<const __m128i*>(&biases_[i]);
-        __m128i* outptr = reinterpret_cast<__m128i*>(&output[i]);
-
-        if constexpr (kPaddedInputDimensions % (kSimdWidth * 2) == 0)
-        {
-          const auto row0 = reinterpret_cast<const __m512i*>(&weights_[offset0]);
-          const auto row1 = reinterpret_cast<const __m512i*>(&weights_[offset1]);
-          const auto row2 = reinterpret_cast<const __m512i*>(&weights_[offset2]);
-          const auto row3 = reinterpret_cast<const __m512i*>(&weights_[offset3]);
-
-  #if defined (USE_VNNI)
-          __m512i sum0 = _mm512_setzero_si512();
-          __m512i sum1 = _mm512_setzero_si512();
-          __m512i sum2 = _mm512_setzero_si512();
-          __m512i sum3 = _mm512_setzero_si512();
-          const IndexType kStart = 0;
-  #else
-          __m512i sum0 = m512_dpbusd_epi32(input_vector512[0], row0[0]);
-          __m512i sum1 = m512_dpbusd_epi32(input_vector512[0], row1[0]);
-          __m512i sum2 = m512_dpbusd_epi32(input_vector512[0], row2[0]);
-          __m512i sum3 = m512_dpbusd_epi32(input_vector512[0], row3[0]);
-          const IndexType kStart = 1;
-  #endif
-
-          for (IndexType j = kStart; j < kNumChunks512; ++j)
-          {
-            const __m512i in = input_vector512[j];
-
-  #if defined (USE_VNNI)
-            m512_add_dpbusd_epi32(sum0, in, row0[j]);
-            m512_add_dpbusd_epi32(sum1, in, row1[j]);
-            m512_add_dpbusd_epi32(sum2, in, row2[j]);
-            m512_add_dpbusd_epi32(sum3, in, row3[j]);
-  #else
-            sum0 = _mm512_add_epi32(sum0, m512_dpbusd_epi32(in, row0[j]));
-            sum1 = _mm512_add_epi32(sum1, m512_dpbusd_epi32(in, row1[j]));
-            sum2 = _mm512_add_epi32(sum2, m512_dpbusd_epi32(in, row2[j]));
-            sum3 = _mm512_add_epi32(sum3, m512_dpbusd_epi32(in, row3[j]));
-  #endif
-          }
-
-          *outptr = m512_haddx4(sum0, sum1, sum2, sum3, bias);
-        }
-        else
-        {
-          const auto row0 = reinterpret_cast<const __m256i*>(&weights_[offset0]);
-          const auto row1 = reinterpret_cast<const __m256i*>(&weights_[offset1]);
-          const auto row2 = reinterpret_cast<const __m256i*>(&weights_[offset2]);
-          const auto row3 = reinterpret_cast<const __m256i*>(&weights_[offset3]);
-
-  #if defined (USE_VNNI)
-          __m256i sum0 = _mm256_setzero_si256();
-          __m256i sum1 = _mm256_setzero_si256();
-          __m256i sum2 = _mm256_setzero_si256();
-          __m256i sum3 = _mm256_setzero_si256();
-          const IndexType kStart = 0;
-  #else
-          __m256i sum0 = m256_dpbusd_epi32(input_vector256[0], row0[0]);
-          __m256i sum1 = m256_dpbusd_epi32(input_vector256[0], row1[0]);
-          __m256i sum2 = m256_dpbusd_epi32(input_vector256[0], row2[0]);
-          __m256i sum3 = m256_dpbusd_epi32(input_vector256[0], row3[0]);
-          const IndexType kStart = 1;
-  #endif
-
-          for (IndexType j = kStart; j < kNumChunks256; ++j)
-          {
-            const __m256i in = input_vector256[j];
-
-  #if defined (USE_VNNI)
-            m256_add_dpbusd_epi32(sum0, in, row0[j]);
-            m256_add_dpbusd_epi32(sum1, in, row1[j]);
-            m256_add_dpbusd_epi32(sum2, in, row2[j]);
-            m256_add_dpbusd_epi32(sum3, in, row3[j]);
-  #else
-            sum0 = _mm256_add_epi32(sum0, m256_dpbusd_epi32(in, row0[j]));
-            sum1 = _mm256_add_epi32(sum1, m256_dpbusd_epi32(in, row1[j]));
-            sum2 = _mm256_add_epi32(sum2, m256_dpbusd_epi32(in, row2[j]));
-            sum3 = _mm256_add_epi32(sum3, m256_dpbusd_epi32(in, row3[j]));
-  #endif
-          }
-
-          *outptr = m256_haddx4(sum0, sum1, sum2, sum3, bias);
-        }
-      }
-    }
-    else if constexpr (kOutputDimensions == 1)
-    {
-      if constexpr (kPaddedInputDimensions % (kSimdWidth * 2) == 0)
-      {
-        const auto row0 = reinterpret_cast<const __m512i*>(&weights_[0]);
-
-  #if defined (USE_VNNI)
-        __m512i sum0 = _mm512_setzero_si512();
-        const IndexType kStart = 0;
-  #else
-        __m512i sum0 = m512_dpbusd_epi32(input_vector512[0], row0[0]);
-        const IndexType kStart = 1;
-  #endif
-
-        for (IndexType j = kStart; j < kNumChunks512; ++j)
-        {
-          const __m512i in = input_vector512[j];
-
-  #if defined (USE_VNNI)
-          m512_add_dpbusd_epi32(sum0, in, row0[j]);
-  #else
-          sum0 = _mm512_add_epi32(sum0, m512_dpbusd_epi32(in, row0[j]));
-  #endif
-        }
-
-        output[0] = m512_hadd(sum0, biases_[0]);
-      }
-      else
-      {
-        const auto row0 = reinterpret_cast<const __m256i*>(&weights_[0]);
-
-  #if defined (USE_VNNI)
-        __m256i sum0 = _mm256_setzero_si256();
-        const IndexType kStart = 0;
-  #else
-        __m256i sum0 = m256_dpbusd_epi32(input_vector256[0], row0[0]);
-        const IndexType kStart = 1;
-  #endif
-
-        for (IndexType j = kStart; j < kNumChunks256; ++j)
-        {
-          const __m256i in = input_vector256[j];
-
-  #if defined (USE_VNNI)
-          m256_add_dpbusd_epi32(sum0, in, row0[j]);
-  #else
-          sum0 = _mm256_add_epi32(sum0, m256_dpbusd_epi32(in, row0[j]));
-  #endif
-        }
-
-        output[0] = m256_hadd(sum0, biases_[0]);
-      }
-    }
-    else
-    {
-      // This case can never happen because kOutputDimensions
-      // is always 1 or a multiple of kSimdWidth.
-      ASSERT_LV5(false);
-    }
-
-  #elif defined (USE_AVX2)
-
-    constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-
-    const auto output = reinterpret_cast<OutputType*>(buffer);
-    const auto input_vector = reinterpret_cast<const __m256i*>(input);
-
-    // kOutputDimensions is either 1 or a multiple of kSimdWidth
-    // because then it is also an input dimension.
-    if constexpr (kOutputDimensions % 4 == 0)
-    {
-      for (IndexType i = 0; i < kOutputDimensions; i += 4)
-      {
-        const IndexType offset0 = (i + 0) * kPaddedInputDimensions;
-        const IndexType offset1 = (i + 1) * kPaddedInputDimensions;
-        const IndexType offset2 = (i + 2) * kPaddedInputDimensions;
-        const IndexType offset3 = (i + 3) * kPaddedInputDimensions;
-
-        const __m128i bias = *reinterpret_cast<const __m128i*>(&biases_[i]);
-        __m128i* outptr = reinterpret_cast<__m128i*>(&output[i]);
-
-        const auto row0 = reinterpret_cast<const __m256i*>(&weights_[offset0]);
-        const auto row1 = reinterpret_cast<const __m256i*>(&weights_[offset1]);
-        const auto row2 = reinterpret_cast<const __m256i*>(&weights_[offset2]);
-        const auto row3 = reinterpret_cast<const __m256i*>(&weights_[offset3]);
-
-  #if defined (USE_VNNI)
-        __m256i sum0 = _mm256_setzero_si256();
-        __m256i sum1 = _mm256_setzero_si256();
-        __m256i sum2 = _mm256_setzero_si256();
-        __m256i sum3 = _mm256_setzero_si256();
-        const IndexType kStart = 0;
-  #else
-        __m256i sum0 = m256_dpbusd_epi32(input_vector[0], row0[0]);
-        __m256i sum1 = m256_dpbusd_epi32(input_vector[0], row1[0]);
-        __m256i sum2 = m256_dpbusd_epi32(input_vector[0], row2[0]);
-        __m256i sum3 = m256_dpbusd_epi32(input_vector[0], row3[0]);
-        const IndexType kStart = 1;
-  #endif
-
-        for (IndexType j = kStart; j < kNumChunks; ++j)
-        {
-          const __m256i in = input_vector[j];
-
-  #if defined (USE_VNNI)
-          m256_add_dpbusd_epi32(sum0, in, row0[j]);
-          m256_add_dpbusd_epi32(sum1, in, row1[j]);
-          m256_add_dpbusd_epi32(sum2, in, row2[j]);
-          m256_add_dpbusd_epi32(sum3, in, row3[j]);
-  #else
-          sum0 = _mm256_add_epi32(sum0, m256_dpbusd_epi32(in, row0[j]));
-          sum1 = _mm256_add_epi32(sum1, m256_dpbusd_epi32(in, row1[j]));
-          sum2 = _mm256_add_epi32(sum2, m256_dpbusd_epi32(in, row2[j]));
-          sum3 = _mm256_add_epi32(sum3, m256_dpbusd_epi32(in, row3[j]));
-  #endif
-        }
-
-        *outptr = m256_haddx4(sum0, sum1, sum2, sum3, bias);
-      }
-    }
-    else if constexpr (kOutputDimensions == 1)
-    {
-      const auto row0 = reinterpret_cast<const __m256i*>(&weights_[0]);
-
-  #if defined (USE_VNNI)
-      __m256i sum0 = _mm256_setzero_si256();
-      const IndexType kStart = 0;
-  #else
-      __m256i sum0 = m256_dpbusd_epi32(input_vector[0], row0[0]);
-      const IndexType kStart = 1;
-  #endif
-
-      for (IndexType j = kStart; j < kNumChunks; ++j)
-      {
-        const __m256i in = input_vector[j];
-
-  #if defined (USE_VNNI)
-        m256_add_dpbusd_epi32(sum0, in, row0[j]);
-  #else
-        sum0 = _mm256_add_epi32(sum0, m256_dpbusd_epi32(in, row0[j]));
-  #endif
-      }
-
-      output[0] = m256_hadd(sum0, biases_[0]);
-    }
-    else
-    {
-      // This case can never happen because kOutputDimensions
-      // is always 1 or a multiple of kSimdWidth.
-      ASSERT_LV5(false);
-    }
-
-  #elif defined (USE_SSSE3)
-
-    constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-
-    auto output = reinterpret_cast<OutputType*>(buffer);
-    const auto input_vector = reinterpret_cast<const __m128i*>(input);
-
-    // kOutputDimensions is either 1 or a multiple of kSimdWidth
-    // because then it is also an input dimension.
-    if constexpr (kOutputDimensions % 4 == 0)
-    {
-      for (IndexType i = 0; i < kOutputDimensions; i += 4)
-      {
-        const IndexType offset0 = (i + 0) * kPaddedInputDimensions;
-        const IndexType offset1 = (i + 1) * kPaddedInputDimensions;
-        const IndexType offset2 = (i + 2) * kPaddedInputDimensions;
-        const IndexType offset3 = (i + 3) * kPaddedInputDimensions;
-
-        const __m128i bias = *reinterpret_cast<const __m128i*>(&biases_[i]);
-        __m128i* outptr = reinterpret_cast<__m128i*>(&output[i]);
-
-        const auto row0 = reinterpret_cast<const __m128i*>(&weights_[offset0]);
-        const auto row1 = reinterpret_cast<const __m128i*>(&weights_[offset1]);
-        const auto row2 = reinterpret_cast<const __m128i*>(&weights_[offset2]);
-        const auto row3 = reinterpret_cast<const __m128i*>(&weights_[offset3]);
-
-          __m128i sum0 = m128_dpbusd_epi32(input_vector[0], row0[0]);
-          __m128i sum1 = m128_dpbusd_epi32(input_vector[0], row1[0]);
-          __m128i sum2 = m128_dpbusd_epi32(input_vector[0], row2[0]);
-          __m128i sum3 = m128_dpbusd_epi32(input_vector[0], row3[0]);
-
-          for (int j = 1; j < (int)kNumChunks; ++j)
-          {
-            const __m128i in = input_vector[j];
-
-            sum0 = _mm_add_epi32(sum0, m128_dpbusd_epi32(in, row0[j]));
-            sum1 = _mm_add_epi32(sum1, m128_dpbusd_epi32(in, row1[j]));
-            sum2 = _mm_add_epi32(sum2, m128_dpbusd_epi32(in, row2[j]));
-            sum3 = _mm_add_epi32(sum3, m128_dpbusd_epi32(in, row3[j]));
-          }
-
-          *outptr = m128_haddx4(sum0, sum1, sum2, sum3, bias);
-        }
-      }
-      else if constexpr (kOutputDimensions == 1)
-      {
-        const auto row0 = reinterpret_cast<const __m128i*>(&weights_[0]);
-
-        __m128i sum0 = m128_dpbusd_epi32(input_vector[0], row0[0]);
-
-        for (int j = 1; j < (int)kNumChunks; ++j) {
-          sum0 = _mm_add_epi32(sum0, m128_dpbusd_epi32(input_vector[j], row0[j]));
-        }
-
-        output[0] = m128_hadd(sum0, biases_[0]);
-      }
-      else
-      {
-          // This case can never happen because kOutputDimensions
-          // is always 1 or a multiple of kSimdWidth.
-          ASSERT_LV5(false);
-      }
-
-  #else  // if not defined (USE_AVX512|USE_AVX2|USE_SSSE3)
-
-  // Use old implementation for the other architectures.
-
-      auto output = reinterpret_cast<OutputType*>(buffer);
-
-  #if defined(USE_SSE2)
-          constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-  #ifndef USE_SSSE3
-          const __m128i kZeros = _mm_setzero_si128();
-  #else
-          const __m128i kOnes = _mm_set1_epi16(1);
-  #endif
-          const auto input_vector = reinterpret_cast<const __m128i*>(input);
-
-  #elif defined(USE_MMX)
-          constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-          const __m64 kZeros = _mm_setzero_si64();
-          const auto input_vector = reinterpret_cast<const __m64*>(input);
-
-  #elif defined(USE_NEON)
-          constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
-          const auto input_vector = reinterpret_cast<const int8x8_t*>(input);
-  #endif
-
-          for (IndexType i = 0; i < kOutputDimensions; ++i) {
-            const IndexType offset = i * kPaddedInputDimensions;
-
-  #if defined(USE_SSE2)
-            __m128i sum_lo = _mm_cvtsi32_si128(biases_[i]);
-            __m128i sum_hi = kZeros;
-            const auto row = reinterpret_cast<const __m128i*>(&weights_[offset]);
-            for (IndexType j = 0; j < kNumChunks; ++j) {
-                __m128i row_j = _mm_load_si128(&row[j]);
-                __m128i input_j = _mm_load_si128(&input_vector[j]);
-                __m128i row_signs = _mm_cmpgt_epi8(kZeros, row_j);
-                __m128i extended_row_lo = _mm_unpacklo_epi8(row_j, row_signs);
-                __m128i extended_row_hi = _mm_unpackhi_epi8(row_j, row_signs);
-                __m128i extended_input_lo = _mm_unpacklo_epi8(input_j, kZeros);
-                __m128i extended_input_hi = _mm_unpackhi_epi8(input_j, kZeros);
-                __m128i product_lo = _mm_madd_epi16(extended_row_lo, extended_input_lo);
-                __m128i product_hi = _mm_madd_epi16(extended_row_hi, extended_input_hi);
-                sum_lo = _mm_add_epi32(sum_lo, product_lo);
-                sum_hi = _mm_add_epi32(sum_hi, product_hi);
-            }
-            __m128i sum = _mm_add_epi32(sum_lo, sum_hi);
-            __m128i sum_high_64 = _mm_shuffle_epi32(sum, _MM_SHUFFLE(1, 0, 3, 2));
-            sum = _mm_add_epi32(sum, sum_high_64);
-            __m128i sum_second_32 = _mm_shufflelo_epi16(sum, _MM_SHUFFLE(1, 0, 3, 2));
-            sum = _mm_add_epi32(sum, sum_second_32);
-      output[i] = _mm_cvtsi128_si32(sum);
-
-  #elif defined(USE_MMX)
-            __m64 sum_lo = _mm_cvtsi32_si64(biases_[i]);
-            __m64 sum_hi = kZeros;
-            const auto row = reinterpret_cast<const __m64*>(&weights_[offset]);
-            for (IndexType j = 0; j < kNumChunks; ++j) {
-                __m64 row_j = row[j];
-                __m64 input_j = input_vector[j];
-                __m64 row_signs = _mm_cmpgt_pi8(kZeros, row_j);
-                __m64 extended_row_lo = _mm_unpacklo_pi8(row_j, row_signs);
-                __m64 extended_row_hi = _mm_unpackhi_pi8(row_j, row_signs);
-                __m64 extended_input_lo = _mm_unpacklo_pi8(input_j, kZeros);
-                __m64 extended_input_hi = _mm_unpackhi_pi8(input_j, kZeros);
-                __m64 product_lo = _mm_madd_pi16(extended_row_lo, extended_input_lo);
-                __m64 product_hi = _mm_madd_pi16(extended_row_hi, extended_input_hi);
-                sum_lo = _mm_add_pi32(sum_lo, product_lo);
-                sum_hi = _mm_add_pi32(sum_hi, product_hi);
-            }
-            __m64 sum = _mm_add_pi32(sum_lo, sum_hi);
-            sum = _mm_add_pi32(sum, _mm_unpackhi_pi32(sum, sum));
-            output[i] = _mm_cvtsi64_si32(sum);
-
-  #elif defined(USE_NEON)
-      int32x4_t sum = {biases_[i]};
-      const auto row = reinterpret_cast<const int8x8_t*>(&weights_[offset]);
-      for (IndexType j = 0; j < kNumChunks; ++j) {
-        int16x8_t product = vmull_s8(input_vector[j * 2], row[j * 2]);
-        product = vmlal_s8(product, input_vector[j * 2 + 1], row[j * 2 + 1]);
-        sum = vpadalq_s16(sum, product);
-      }
-      output[i] = sum[0] + sum[1] + sum[2] + sum[3];
-
-  #else
-      // CPUに依存しないコード
-      OutputType sum = biases_[i];
-      for (IndexType j = 0; j < kInputDimensions; ++j) {
-        sum += weights_[offset + j] * input[j];
-      }
-      output[i] = sum;
-  #endif
-
-    }
-  #if defined(USE_MMX)
-        _mm_empty();
-  #endif
-
-  #endif  // not defined (USE_AVX512|USE_AVX2|USE_SSSE3)
-
-    return output;
-  }
-
- private:
-  // パラメータの型
-  using BiasType = OutputType;
-  using WeightType = std::int8_t;
-
-  // 学習用クラスをfriendにする
-  friend class Trainer<AffineTransform>;
-
-  // この層の直前の層
-  PreviousLayer previous_layer_;
-
-  // パラメータ
-  alignas(kCacheLineSize) BiasType biases_[kOutputDimensions];
-  alignas(kCacheLineSize)
-      WeightType weights_[kOutputDimensions * kPaddedInputDimensions];
+		[[maybe_unused]] auto m512_hadd256x16 =
+		    [m512_hadd128x16_interleave](__m512i sum0, __m512i sum1, __m512i sum2, __m512i sum3, __m512i sum4,
+		                                 __m512i sum5, __m512i sum6, __m512i sum7, __m512i bias) -> __m512i {
+			__m512i suma = m512_hadd128x16_interleave(sum0, sum1, sum2, sum3);
+			__m512i sumb = m512_hadd128x16_interleave(sum4, sum5, sum6, sum7);
+
+			__m512i indices0 = _mm512_setr_epi64(0, 1, 8, 9, 4, 5, 12, 13);
+			__m512i indices1 = _mm512_setr_epi64(2, 3, 10, 11, 6, 7, 14, 15);
+			__m512i x        = _mm512_add_epi32(_mm512_permutex2var_epi64(suma, indices0, sumb),
+                                         _mm512_permutex2var_epi64(suma, indices1, sumb));
+
+			__m512i indices = _mm512_setr_epi32(0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15);
+			return _mm512_add_epi32(_mm512_permutexvar_epi32(indices, x), bias);
+		};
+
+#if defined(USE_VNNI)
+		[[maybe_unused]] auto m512_add_dpbusd_epi32 = [=](__m512i& acc, __m512i a, __m512i b) {
+			acc = _mm512_dpbusd_epi32(acc, a, b);
+#else
+		[[maybe_unused]] auto m512_dpbusd_epi32 = [=](__m512i a, __m512i b) -> __m512i {
+			__m512i product0 = _mm512_maddubs_epi16(a, b);
+			return _mm512_madd_epi16(product0, kOnes512);
+#endif
+		};
+
+#endif
+#if defined(USE_AVX2)
+
+		[[maybe_unused]] const __m256i kOnes256 = _mm256_set1_epi16(1);
+
+		[[maybe_unused]] auto m256_hadd = [](__m256i sum, int bias) -> int {
+			__m128i sum128 = _mm_add_epi32(_mm256_castsi256_si128(sum), _mm256_extracti128_si256(sum, 1));
+			sum128         = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_BADC));
+			sum128         = _mm_add_epi32(sum128, _mm_shuffle_epi32(sum128, _MM_PERM_CDAB));
+			return _mm_cvtsi128_si32(sum128) + bias;
+		};
+
+		[[maybe_unused]] auto m256_haddx4 = [](__m256i sum0, __m256i sum1, __m256i sum2, __m256i sum3,
+		                                       __m128i bias) -> __m128i {
+			sum0 = _mm256_hadd_epi32(sum0, sum1);
+			sum2 = _mm256_hadd_epi32(sum2, sum3);
+
+			sum0 = _mm256_hadd_epi32(sum0, sum2);
+
+			__m128i sum128lo = _mm256_castsi256_si128(sum0);
+			__m128i sum128hi = _mm256_extracti128_si256(sum0, 1);
+
+			return _mm_add_epi32(_mm_add_epi32(sum128lo, sum128hi), bias);
+		};
+#if defined(USE_VNNI)
+		[[maybe_unused]] auto m256_add_dpbusd_epi32 = [=](__m256i& acc, __m256i a, __m256i b) {
+			acc = _mm256_dpbusd_epi32(acc, a, b);
+#else
+		[[maybe_unused]] auto m256_dpbusd_epi32 = [=](__m256i a, __m256i b) -> __m256i {
+			__m256i product0 = _mm256_maddubs_epi16(a, b);
+			return _mm256_madd_epi16(product0, kOnes256);
+#endif
+		};
+
+#endif
+
+#if defined(USE_SSSE3)
+
+		[[maybe_unused]] const __m128i kOnes128 = _mm_set1_epi16(1);
+
+		[[maybe_unused]] auto m128_hadd = [](__m128i sum, int bias) -> int {
+			sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4E));  //_MM_PERM_BADC
+			sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xB1));  //_MM_PERM_CDAB
+			return _mm_cvtsi128_si32(sum) + bias;
+		};
+
+		[[maybe_unused]] auto m128_haddx4 = [](__m128i sum0, __m128i sum1, __m128i sum2, __m128i sum3,
+		                                       __m128i bias) -> __m128i {
+			sum0 = _mm_hadd_epi32(sum0, sum1);
+			sum2 = _mm_hadd_epi32(sum2, sum3);
+
+			sum0 = _mm_hadd_epi32(sum0, sum2);
+
+			return _mm_add_epi32(sum0, bias);
+		};
+
+		[[maybe_unused]] auto m128_dpbusd_epi32 = [=](__m128i a, __m128i b) -> __m128i {
+			__m128i product0 = _mm_maddubs_epi16(a, b);
+			return _mm_madd_epi16(product0, kOnes128);
+		};
+
+#endif
+
+#if defined(USE_AVX512)
+
+		constexpr IndexType kNumChunks512 = kPaddedInputDimensions / (kSimdWidth * 2);
+		constexpr IndexType kNumChunks256 = kPaddedInputDimensions / kSimdWidth;
+
+		const auto output = reinterpret_cast<OutputType*>(buffer);
+
+		// Since to saturate a zmm register it takes 64 bytes we
+		// cannot use AVX512 for the smaller affine transforms.
+		// Instead we fallback to a AVX2 implementation if the
+		// kInputDimensions isn't a multiple of 64.
+		// Note that this means that for example for
+		// kInputDimensions of 96 we fallback to AVX2 even though
+		// the first 64 elements could be processed with AVX512.
+		// This is caused by mixing the __m256 and __m512 variables
+		// required to better handle that case and it would
+		// require handling more cases statically not to lose performance.
+		// This should be revisited if such input dimensions are to be considered.
+		[[maybe_unused]] const auto input_vector512 = reinterpret_cast<const __m512i*>(input);
+		[[maybe_unused]] const auto input_vector256 = reinterpret_cast<const __m256i*>(input);
+
+		// kOutputDimensions is either 1 or a multiple of kSimdWidth
+		// because then it is also an input dimension.
+		if constexpr (kOutputDimensions % 16 == 0 && kNumChunks256 == 1) {
+			for (IndexType i = 0; i < kOutputDimensions; i += 16) {
+				const IndexType offset01a = (i + 0) * kPaddedInputDimensions;
+				const IndexType offset23a = (i + 2) * kPaddedInputDimensions;
+				const IndexType offset45a = (i + 4) * kPaddedInputDimensions;
+				const IndexType offset67a = (i + 6) * kPaddedInputDimensions;
+				const IndexType offset01b = (i + 8) * kPaddedInputDimensions;
+				const IndexType offset23b = (i + 10) * kPaddedInputDimensions;
+				const IndexType offset45b = (i + 12) * kPaddedInputDimensions;
+				const IndexType offset67b = (i + 14) * kPaddedInputDimensions;
+
+				const __m512i bias   = *reinterpret_cast<const __m512i*>(&biases_[i]);
+				__m512i*      outptr = reinterpret_cast<__m512i*>(&output[i]);
+
+				const auto row01a = *reinterpret_cast<const __m512i*>(&weights_[offset01a]);
+				const auto row23a = *reinterpret_cast<const __m512i*>(&weights_[offset23a]);
+				const auto row45a = *reinterpret_cast<const __m512i*>(&weights_[offset45a]);
+				const auto row67a = *reinterpret_cast<const __m512i*>(&weights_[offset67a]);
+				const auto row01b = *reinterpret_cast<const __m512i*>(&weights_[offset01b]);
+				const auto row23b = *reinterpret_cast<const __m512i*>(&weights_[offset23b]);
+				const auto row45b = *reinterpret_cast<const __m512i*>(&weights_[offset45b]);
+				const auto row67b = *reinterpret_cast<const __m512i*>(&weights_[offset67b]);
+
+				const __m256i in256 = input_vector256[0];
+				const __m512i in    = _mm512_inserti64x4(_mm512_castsi256_si512(in256), in256, 1);
+
+#if defined(USE_VNNI)
+				__m512i sum01a = _mm512_setzero_si512();
+				__m512i sum23a = _mm512_setzero_si512();
+				__m512i sum45a = _mm512_setzero_si512();
+				__m512i sum67a = _mm512_setzero_si512();
+				__m512i sum01b = _mm512_setzero_si512();
+				__m512i sum23b = _mm512_setzero_si512();
+				__m512i sum45b = _mm512_setzero_si512();
+				__m512i sum67b = _mm512_setzero_si512();
+
+				m512_add_dpbusd_epi32(sum01a, in, row01a);
+				m512_add_dpbusd_epi32(sum23a, in, row23a);
+				m512_add_dpbusd_epi32(sum45a, in, row45a);
+				m512_add_dpbusd_epi32(sum67a, in, row67a);
+				m512_add_dpbusd_epi32(sum01b, in, row01b);
+				m512_add_dpbusd_epi32(sum23b, in, row23b);
+				m512_add_dpbusd_epi32(sum45b, in, row45b);
+				m512_add_dpbusd_epi32(sum67b, in, row67b);
+#else
+				__m512i sum01a = m512_dpbusd_epi32(in, row01a);
+				__m512i sum23a = m512_dpbusd_epi32(in, row23a);
+				__m512i sum45a = m512_dpbusd_epi32(in, row45a);
+				__m512i sum67a = m512_dpbusd_epi32(in, row67a);
+				__m512i sum01b = m512_dpbusd_epi32(in, row01b);
+				__m512i sum23b = m512_dpbusd_epi32(in, row23b);
+				__m512i sum45b = m512_dpbusd_epi32(in, row45b);
+				__m512i sum67b = m512_dpbusd_epi32(in, row67b);
+#endif
+
+				*outptr = m512_hadd256x16(sum01a, sum23a, sum45a, sum67a, sum01b, sum23b, sum45b, sum67b, bias);
+			}
+		} else if constexpr (kOutputDimensions % 4 == 0) {
+			for (IndexType i = 0; i < kOutputDimensions; i += 4) {
+				const IndexType offset0 = (i + 0) * kPaddedInputDimensions;
+				const IndexType offset1 = (i + 1) * kPaddedInputDimensions;
+				const IndexType offset2 = (i + 2) * kPaddedInputDimensions;
+				const IndexType offset3 = (i + 3) * kPaddedInputDimensions;
+
+				const __m128i bias   = *reinterpret_cast<const __m128i*>(&biases_[i]);
+				__m128i*      outptr = reinterpret_cast<__m128i*>(&output[i]);
+
+				if constexpr (kPaddedInputDimensions % (kSimdWidth * 2) == 0) {
+					const auto row0 = reinterpret_cast<const __m512i*>(&weights_[offset0]);
+					const auto row1 = reinterpret_cast<const __m512i*>(&weights_[offset1]);
+					const auto row2 = reinterpret_cast<const __m512i*>(&weights_[offset2]);
+					const auto row3 = reinterpret_cast<const __m512i*>(&weights_[offset3]);
+
+#if defined(USE_VNNI)
+					__m512i         sum0   = _mm512_setzero_si512();
+					__m512i         sum1   = _mm512_setzero_si512();
+					__m512i         sum2   = _mm512_setzero_si512();
+					__m512i         sum3   = _mm512_setzero_si512();
+					const IndexType kStart = 0;
+#else
+					__m512i         sum0   = m512_dpbusd_epi32(input_vector512[0], row0[0]);
+					__m512i         sum1   = m512_dpbusd_epi32(input_vector512[0], row1[0]);
+					__m512i         sum2   = m512_dpbusd_epi32(input_vector512[0], row2[0]);
+					__m512i         sum3   = m512_dpbusd_epi32(input_vector512[0], row3[0]);
+					const IndexType kStart = 1;
+#endif
+
+					for (IndexType j = kStart; j < kNumChunks512; ++j) {
+						const __m512i in = input_vector512[j];
+
+#if defined(USE_VNNI)
+						m512_add_dpbusd_epi32(sum0, in, row0[j]);
+						m512_add_dpbusd_epi32(sum1, in, row1[j]);
+						m512_add_dpbusd_epi32(sum2, in, row2[j]);
+						m512_add_dpbusd_epi32(sum3, in, row3[j]);
+#else
+						sum0 = _mm512_add_epi32(sum0, m512_dpbusd_epi32(in, row0[j]));
+						sum1 = _mm512_add_epi32(sum1, m512_dpbusd_epi32(in, row1[j]));
+						sum2 = _mm512_add_epi32(sum2, m512_dpbusd_epi32(in, row2[j]));
+						sum3 = _mm512_add_epi32(sum3, m512_dpbusd_epi32(in, row3[j]));
+#endif
+					}
+
+					*outptr = m512_haddx4(sum0, sum1, sum2, sum3, bias);
+				} else {
+					const auto row0 = reinterpret_cast<const __m256i*>(&weights_[offset0]);
+					const auto row1 = reinterpret_cast<const __m256i*>(&weights_[offset1]);
+					const auto row2 = reinterpret_cast<const __m256i*>(&weights_[offset2]);
+					const auto row3 = reinterpret_cast<const __m256i*>(&weights_[offset3]);
+
+#if defined(USE_VNNI)
+					__m256i         sum0   = _mm256_setzero_si256();
+					__m256i         sum1   = _mm256_setzero_si256();
+					__m256i         sum2   = _mm256_setzero_si256();
+					__m256i         sum3   = _mm256_setzero_si256();
+					const IndexType kStart = 0;
+#else
+					__m256i         sum0   = m256_dpbusd_epi32(input_vector256[0], row0[0]);
+					__m256i         sum1   = m256_dpbusd_epi32(input_vector256[0], row1[0]);
+					__m256i         sum2   = m256_dpbusd_epi32(input_vector256[0], row2[0]);
+					__m256i         sum3   = m256_dpbusd_epi32(input_vector256[0], row3[0]);
+					const IndexType kStart = 1;
+#endif
+
+					for (IndexType j = kStart; j < kNumChunks256; ++j) {
+						const __m256i in = input_vector256[j];
+
+#if defined(USE_VNNI)
+						m256_add_dpbusd_epi32(sum0, in, row0[j]);
+						m256_add_dpbusd_epi32(sum1, in, row1[j]);
+						m256_add_dpbusd_epi32(sum2, in, row2[j]);
+						m256_add_dpbusd_epi32(sum3, in, row3[j]);
+#else
+						sum0 = _mm256_add_epi32(sum0, m256_dpbusd_epi32(in, row0[j]));
+						sum1 = _mm256_add_epi32(sum1, m256_dpbusd_epi32(in, row1[j]));
+						sum2 = _mm256_add_epi32(sum2, m256_dpbusd_epi32(in, row2[j]));
+						sum3 = _mm256_add_epi32(sum3, m256_dpbusd_epi32(in, row3[j]));
+#endif
+					}
+
+					*outptr = m256_haddx4(sum0, sum1, sum2, sum3, bias);
+				}
+			}
+		} else if constexpr (kOutputDimensions == 1) {
+			if constexpr (kPaddedInputDimensions % (kSimdWidth * 2) == 0) {
+				const auto row0 = reinterpret_cast<const __m512i*>(&weights_[0]);
+
+#if defined(USE_VNNI)
+				__m512i         sum0   = _mm512_setzero_si512();
+				const IndexType kStart = 0;
+#else
+				__m512i         sum0   = m512_dpbusd_epi32(input_vector512[0], row0[0]);
+				const IndexType kStart = 1;
+#endif
+
+				for (IndexType j = kStart; j < kNumChunks512; ++j) {
+					const __m512i in = input_vector512[j];
+
+#if defined(USE_VNNI)
+					m512_add_dpbusd_epi32(sum0, in, row0[j]);
+#else
+					sum0 = _mm512_add_epi32(sum0, m512_dpbusd_epi32(in, row0[j]));
+#endif
+				}
+
+				output[0] = m512_hadd(sum0, biases_[0]);
+			} else {
+				const auto row0 = reinterpret_cast<const __m256i*>(&weights_[0]);
+
+#if defined(USE_VNNI)
+				__m256i         sum0   = _mm256_setzero_si256();
+				const IndexType kStart = 0;
+#else
+				__m256i         sum0   = m256_dpbusd_epi32(input_vector256[0], row0[0]);
+				const IndexType kStart = 1;
+#endif
+
+				for (IndexType j = kStart; j < kNumChunks256; ++j) {
+					const __m256i in = input_vector256[j];
+
+#if defined(USE_VNNI)
+					m256_add_dpbusd_epi32(sum0, in, row0[j]);
+#else
+					sum0 = _mm256_add_epi32(sum0, m256_dpbusd_epi32(in, row0[j]));
+#endif
+				}
+
+				output[0] = m256_hadd(sum0, biases_[0]);
+			}
+		} else {
+			// This case can never happen because kOutputDimensions
+			// is always 1 or a multiple of kSimdWidth.
+			ASSERT_LV5(false);
+		}
+
+#elif defined(USE_AVX2)
+
+		constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
+
+		const auto output       = reinterpret_cast<OutputType*>(buffer);
+		const auto input_vector = reinterpret_cast<const __m256i*>(input);
+
+		// kOutputDimensions is either 1 or a multiple of kSimdWidth
+		// because then it is also an input dimension.
+		if constexpr (kOutputDimensions % 4 == 0) {
+			for (IndexType i = 0; i < kOutputDimensions; i += 4) {
+				const IndexType offset0 = (i + 0) * kPaddedInputDimensions;
+				const IndexType offset1 = (i + 1) * kPaddedInputDimensions;
+				const IndexType offset2 = (i + 2) * kPaddedInputDimensions;
+				const IndexType offset3 = (i + 3) * kPaddedInputDimensions;
+
+				const __m128i bias   = *reinterpret_cast<const __m128i*>(&biases_[i]);
+				__m128i*      outptr = reinterpret_cast<__m128i*>(&output[i]);
+
+				const auto row0 = reinterpret_cast<const __m256i*>(&weights_[offset0]);
+				const auto row1 = reinterpret_cast<const __m256i*>(&weights_[offset1]);
+				const auto row2 = reinterpret_cast<const __m256i*>(&weights_[offset2]);
+				const auto row3 = reinterpret_cast<const __m256i*>(&weights_[offset3]);
+
+#if defined(USE_VNNI)
+				__m256i         sum0   = _mm256_setzero_si256();
+				__m256i         sum1   = _mm256_setzero_si256();
+				__m256i         sum2   = _mm256_setzero_si256();
+				__m256i         sum3   = _mm256_setzero_si256();
+				const IndexType kStart = 0;
+#else
+				__m256i         sum0   = m256_dpbusd_epi32(input_vector[0], row0[0]);
+				__m256i         sum1   = m256_dpbusd_epi32(input_vector[0], row1[0]);
+				__m256i         sum2   = m256_dpbusd_epi32(input_vector[0], row2[0]);
+				__m256i         sum3   = m256_dpbusd_epi32(input_vector[0], row3[0]);
+				const IndexType kStart = 1;
+#endif
+
+				for (IndexType j = kStart; j < kNumChunks; ++j) {
+					const __m256i in = input_vector[j];
+
+#if defined(USE_VNNI)
+					m256_add_dpbusd_epi32(sum0, in, row0[j]);
+					m256_add_dpbusd_epi32(sum1, in, row1[j]);
+					m256_add_dpbusd_epi32(sum2, in, row2[j]);
+					m256_add_dpbusd_epi32(sum3, in, row3[j]);
+#else
+					sum0 = _mm256_add_epi32(sum0, m256_dpbusd_epi32(in, row0[j]));
+					sum1 = _mm256_add_epi32(sum1, m256_dpbusd_epi32(in, row1[j]));
+					sum2 = _mm256_add_epi32(sum2, m256_dpbusd_epi32(in, row2[j]));
+					sum3 = _mm256_add_epi32(sum3, m256_dpbusd_epi32(in, row3[j]));
+#endif
+				}
+
+				*outptr = m256_haddx4(sum0, sum1, sum2, sum3, bias);
+			}
+		} else if constexpr (kOutputDimensions == 1) {
+			const auto row0 = reinterpret_cast<const __m256i*>(&weights_[0]);
+
+#if defined(USE_VNNI)
+			__m256i         sum0   = _mm256_setzero_si256();
+			const IndexType kStart = 0;
+#else
+			__m256i sum0 = m256_dpbusd_epi32(input_vector[0], row0[0]);
+			const IndexType kStart = 1;
+#endif
+
+			for (IndexType j = kStart; j < kNumChunks; ++j) {
+				const __m256i in = input_vector[j];
+
+#if defined(USE_VNNI)
+				m256_add_dpbusd_epi32(sum0, in, row0[j]);
+#else
+				sum0 = _mm256_add_epi32(sum0, m256_dpbusd_epi32(in, row0[j]));
+#endif
+			}
+
+			output[0] = m256_hadd(sum0, biases_[0]);
+		} else {
+			// This case can never happen because kOutputDimensions
+			// is always 1 or a multiple of kSimdWidth.
+			ASSERT_LV5(false);
+		}
+
+#elif defined(USE_SSSE3)
+
+		constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
+
+		auto       output       = reinterpret_cast<OutputType*>(buffer);
+		const auto input_vector = reinterpret_cast<const __m128i*>(input);
+
+		// kOutputDimensions is either 1 or a multiple of kSimdWidth
+		// because then it is also an input dimension.
+		if constexpr (kOutputDimensions % 4 == 0) {
+			for (IndexType i = 0; i < kOutputDimensions; i += 4) {
+				const IndexType offset0 = (i + 0) * kPaddedInputDimensions;
+				const IndexType offset1 = (i + 1) * kPaddedInputDimensions;
+				const IndexType offset2 = (i + 2) * kPaddedInputDimensions;
+				const IndexType offset3 = (i + 3) * kPaddedInputDimensions;
+
+				const __m128i bias   = *reinterpret_cast<const __m128i*>(&biases_[i]);
+				__m128i*      outptr = reinterpret_cast<__m128i*>(&output[i]);
+
+				const auto row0 = reinterpret_cast<const __m128i*>(&weights_[offset0]);
+				const auto row1 = reinterpret_cast<const __m128i*>(&weights_[offset1]);
+				const auto row2 = reinterpret_cast<const __m128i*>(&weights_[offset2]);
+				const auto row3 = reinterpret_cast<const __m128i*>(&weights_[offset3]);
+
+				__m128i sum0 = m128_dpbusd_epi32(input_vector[0], row0[0]);
+				__m128i sum1 = m128_dpbusd_epi32(input_vector[0], row1[0]);
+				__m128i sum2 = m128_dpbusd_epi32(input_vector[0], row2[0]);
+				__m128i sum3 = m128_dpbusd_epi32(input_vector[0], row3[0]);
+
+				for (int j = 1; j < (int)kNumChunks; ++j) {
+					const __m128i in = input_vector[j];
+
+					sum0 = _mm_add_epi32(sum0, m128_dpbusd_epi32(in, row0[j]));
+					sum1 = _mm_add_epi32(sum1, m128_dpbusd_epi32(in, row1[j]));
+					sum2 = _mm_add_epi32(sum2, m128_dpbusd_epi32(in, row2[j]));
+					sum3 = _mm_add_epi32(sum3, m128_dpbusd_epi32(in, row3[j]));
+				}
+
+				*outptr = m128_haddx4(sum0, sum1, sum2, sum3, bias);
+			}
+		} else if constexpr (kOutputDimensions == 1) {
+			const auto row0 = reinterpret_cast<const __m128i*>(&weights_[0]);
+
+			__m128i sum0 = m128_dpbusd_epi32(input_vector[0], row0[0]);
+
+			for (int j = 1; j < (int)kNumChunks; ++j) {
+				sum0 = _mm_add_epi32(sum0, m128_dpbusd_epi32(input_vector[j], row0[j]));
+			}
+
+			output[0] = m128_hadd(sum0, biases_[0]);
+		} else {
+			// This case can never happen because kOutputDimensions
+			// is always 1 or a multiple of kSimdWidth.
+			ASSERT_LV5(false);
+		}
+
+#else  // if not defined (USE_AVX512|USE_AVX2|USE_SSSE3)
+
+		// Use old implementation for the other architectures.
+
+		auto output = reinterpret_cast<OutputType*>(buffer);
+
+#if defined(USE_SSE2)
+		constexpr IndexType kNumChunks = kPaddedInputDimensions / kSimdWidth;
+#ifndef USE_SSSE3
+		const __m128i kZeros = _mm_setzero_si128();
+#else
+		const __m128i kOnes = _mm_set1_epi16(1);
+#endif
+		const auto input_vector = reinterpret_cast<const __m128i*>(input);
+
+#elif defined(USE_MMX)
+		constexpr IndexType kNumChunks   = kPaddedInputDimensions / kSimdWidth;
+		const __m64         kZeros       = _mm_setzero_si64();
+		const auto          input_vector = reinterpret_cast<const __m64*>(input);
+
+#elif defined(USE_NEON)
+		constexpr IndexType kNumChunks   = kPaddedInputDimensions / kSimdWidth;
+		const auto          input_vector = reinterpret_cast<const int8x8_t*>(input);
+#endif
+
+		for (IndexType i = 0; i < kOutputDimensions; ++i) {
+			const IndexType offset = i * kPaddedInputDimensions;
+
+#if defined(USE_SSE2)
+			__m128i    sum_lo = _mm_cvtsi32_si128(biases_[i]);
+			__m128i    sum_hi = kZeros;
+			const auto row    = reinterpret_cast<const __m128i*>(&weights_[offset]);
+			for (IndexType j = 0; j < kNumChunks; ++j) {
+				__m128i row_j             = _mm_load_si128(&row[j]);
+				__m128i input_j           = _mm_load_si128(&input_vector[j]);
+				__m128i row_signs         = _mm_cmpgt_epi8(kZeros, row_j);
+				__m128i extended_row_lo   = _mm_unpacklo_epi8(row_j, row_signs);
+				__m128i extended_row_hi   = _mm_unpackhi_epi8(row_j, row_signs);
+				__m128i extended_input_lo = _mm_unpacklo_epi8(input_j, kZeros);
+				__m128i extended_input_hi = _mm_unpackhi_epi8(input_j, kZeros);
+				__m128i product_lo        = _mm_madd_epi16(extended_row_lo, extended_input_lo);
+				__m128i product_hi        = _mm_madd_epi16(extended_row_hi, extended_input_hi);
+				sum_lo                    = _mm_add_epi32(sum_lo, product_lo);
+				sum_hi                    = _mm_add_epi32(sum_hi, product_hi);
+			}
+			__m128i sum           = _mm_add_epi32(sum_lo, sum_hi);
+			__m128i sum_high_64   = _mm_shuffle_epi32(sum, _MM_SHUFFLE(1, 0, 3, 2));
+			sum                   = _mm_add_epi32(sum, sum_high_64);
+			__m128i sum_second_32 = _mm_shufflelo_epi16(sum, _MM_SHUFFLE(1, 0, 3, 2));
+			sum                   = _mm_add_epi32(sum, sum_second_32);
+			output[i]             = _mm_cvtsi128_si32(sum);
+
+#elif defined(USE_MMX)
+			__m64      sum_lo = _mm_cvtsi32_si64(biases_[i]);
+			__m64      sum_hi = kZeros;
+			const auto row    = reinterpret_cast<const __m64*>(&weights_[offset]);
+			for (IndexType j = 0; j < kNumChunks; ++j) {
+				__m64 row_j             = row[j];
+				__m64 input_j           = input_vector[j];
+				__m64 row_signs         = _mm_cmpgt_pi8(kZeros, row_j);
+				__m64 extended_row_lo   = _mm_unpacklo_pi8(row_j, row_signs);
+				__m64 extended_row_hi   = _mm_unpackhi_pi8(row_j, row_signs);
+				__m64 extended_input_lo = _mm_unpacklo_pi8(input_j, kZeros);
+				__m64 extended_input_hi = _mm_unpackhi_pi8(input_j, kZeros);
+				__m64 product_lo        = _mm_madd_pi16(extended_row_lo, extended_input_lo);
+				__m64 product_hi        = _mm_madd_pi16(extended_row_hi, extended_input_hi);
+				sum_lo                  = _mm_add_pi32(sum_lo, product_lo);
+				sum_hi                  = _mm_add_pi32(sum_hi, product_hi);
+			}
+			__m64 sum = _mm_add_pi32(sum_lo, sum_hi);
+			sum       = _mm_add_pi32(sum, _mm_unpackhi_pi32(sum, sum));
+			output[i] = _mm_cvtsi64_si32(sum);
+
+#elif defined(USE_NEON)
+			int32x4_t  sum = {biases_[i]};
+			const auto row = reinterpret_cast<const int8x8_t*>(&weights_[offset]);
+			for (IndexType j = 0; j < kNumChunks; ++j) {
+				int16x8_t product = vmull_s8(input_vector[j * 2], row[j * 2]);
+				product           = vmlal_s8(product, input_vector[j * 2 + 1], row[j * 2 + 1]);
+				sum               = vpadalq_s16(sum, product);
+			}
+			output[i] = sum[0] + sum[1] + sum[2] + sum[3];
+
+#else
+			// CPUに依存しないコード
+			OutputType sum = biases_[i];
+			for (IndexType j = 0; j < kInputDimensions; ++j) {
+				sum += weights_[offset + j] * input[j];
+			}
+			output[i] = sum;
+#endif
+		}
+#if defined(USE_MMX)
+		_mm_empty();
+#endif
+
+#endif  // not defined (USE_AVX512|USE_AVX2|USE_SSSE3)
+
+		return output;
+	}
+
+   private:
+	// パラメータの型
+	using BiasType   = OutputType;
+	using WeightType = std::int8_t;
+
+	// 学習用クラスをfriendにする
+	friend class Trainer<AffineTransform>;
+
+	// この層の直前の層
+	PreviousLayer previous_layer_;
+
+	// パラメータ
+	alignas(kCacheLineSize) BiasType biases_[kOutputDimensions];
+	alignas(kCacheLineSize) WeightType weights_[kOutputDimensions * kPaddedInputDimensions];
 };
 
 }  // namespace Eval::NNUE::Layers
 
 #endif  // defined(EVAL_NNUE)
 
-#endif // #ifndef NNUE_LAYERS_AFFINE_TRANSFORM_H_INCLUDED
+#endif  // #ifndef NNUE_LAYERS_AFFINE_TRANSFORM_H_INCLUDED

--- a/source/eval/nnue/nnue_feature_transformer.h
+++ b/source/eval/nnue/nnue_feature_transformer.h
@@ -1,7 +1,8 @@
-﻿// NNUE評価関数の入力特徴量の変換を行うクラス
+﻿// A class that converts the input features of the NNUE evaluation function
+// NNUE評価関数の入力特徴量の変換を行うクラス
 
-#ifndef _NNUE_FEATURE_TRANSFORMER_H_
-#define _NNUE_FEATURE_TRANSFORMER_H_
+#ifndef _NNUE_FEATURE_TRANSFORMER_H_INCLUDED
+#define _NNUE_FEATURE_TRANSFORMER_H_INCLUDED
 
 #include "../../config.h"
 
@@ -13,33 +14,100 @@
 
 #include <cstring> // std::memset()
 
-namespace Eval {
+namespace Eval::NNUE {
 
-namespace NNUE {
+// If vector instructions are enabled, we update and refresh the
+// accumulator tile by tile such that each tile fits in the CPU's
+// vector registers.
+// ベクトル命令が有効な場合、変数のタイルを、
+// 各タイルがCPUのベクトルレジスタに収まるように、更新してリフレッシュする。
+#define VECTOR
 
+#if defined(USE_AVX512)
+typedef __m512i vec_t;
+#define vec_load(a) _mm512_load_si512(a)
+#define vec_store(a,b) _mm512_store_si512(a,b)
+#define vec_add_16(a,b) _mm512_add_epi16(a,b)
+#define vec_sub_16(a,b) _mm512_sub_epi16(a,b)
+#define vec_zero _mm512_setzero_si512()
+static constexpr IndexType kNumRegs = 8; // only 8 are needed
+
+#elif defined(USE_AVX2)
+typedef __m256i vec_t;
+#define vec_load(a) _mm256_load_si256(a)
+#define vec_store(a,b) _mm256_store_si256(a,b)
+#define vec_add_16(a,b) _mm256_add_epi16(a,b)
+#define vec_sub_16(a,b) _mm256_sub_epi16(a,b)
+#define vec_zero _mm256_setzero_si256()
+static constexpr IndexType kNumRegs = 16;
+
+#elif defined(USE_SSE2)
+typedef __m128i vec_t;
+#define vec_load(a) (*(a))
+#define vec_store(a,b) *(a)=(b)
+#define vec_add_16(a,b) _mm_add_epi16(a,b)
+#define vec_sub_16(a,b) _mm_sub_epi16(a,b)
+#define vec_zero _mm_setzero_si128()
+static constexpr IndexType kNumRegs = Is64Bit ? 16 : 8;
+
+#elif defined(USE_MMX)
+typedef __m64 vec_t;
+#define vec_load(a) (*(a))
+#define vec_store(a,b) *(a)=(b)
+#define vec_add_16(a,b) _mm_add_pi16(a,b)
+#define vec_sub_16(a,b) _mm_sub_pi16(a,b)
+#define vec_zero _mm_setzero_si64()
+static constexpr IndexType kNumRegs = 8;
+
+#elif defined(USE_NEON)
+typedef int16x8_t vec_t;
+#define vec_load(a) (*(a))
+#define vec_store(a,b) *(a)=(b)
+#define vec_add_16(a,b) vaddq_s16(a,b)
+#define vec_sub_16(a,b) vsubq_s16(a,b)
+#define vec_zero {0}
+static constexpr IndexType kNumRegs = 16;
+
+#else
+#undef VECTOR
+
+#endif
+
+// Input feature converter
 // 入力特徴量変換器
 class FeatureTransformer {
  private:
+  // Number of output dimensions for one side
   // 片側分の出力の次元数
   static constexpr IndexType kHalfDimensions = kTransformedFeatureDimensions;
 
+#if defined(VECTOR)
+  static constexpr IndexType kTileHeight = kNumRegs * sizeof(vec_t) / 2;
+  static_assert(kHalfDimensions % kTileHeight == 0, "kTileHeight must divide kHalfDimensions");
+#endif
+
  public:
+  // Output type
   // 出力の型
   using OutputType = TransformedFeatureType;
 
+  // Number of input/output dimensions
   // 入出力の次元数
   static constexpr IndexType kInputDimensions = RawFeatures::kDimensions;
   static constexpr IndexType kOutputDimensions = kHalfDimensions * 2;
 
+  // Size of forward propagation buffer
   // 順伝播用バッファのサイズ
   static constexpr std::size_t kBufferSize =
       kOutputDimensions * sizeof(OutputType);
 
+  // Hash value embedded in the evaluation file
   // 評価関数ファイルに埋め込むハッシュ値
   static constexpr std::uint32_t GetHashValue() {
     return RawFeatures::kHashValue ^ kOutputDimensions;
   }
 
+  // A string that represents the structure
   // 構造を表す文字列
   static std::string GetStructureString() {
     return RawFeatures::GetName() + "[" +
@@ -47,15 +115,17 @@ class FeatureTransformer {
         std::to_string(kHalfDimensions) + "x2]";
   }
 
+  // Read network parameters
   // パラメータを読み込む
   bool ReadParameters(std::istream& stream) {
-    stream.read(reinterpret_cast<char*>(biases_),
-                kHalfDimensions * sizeof(BiasType));
-    stream.read(reinterpret_cast<char*>(weights_),
-                kHalfDimensions * kInputDimensions * sizeof(WeightType));
+    for (std::size_t i = 0; i < kHalfDimensions; ++i)
+      biases_[i] = read_little_endian<BiasType>(stream);
+    for (std::size_t i = 0; i < kHalfDimensions * kInputDimensions; ++i)
+      weights_[i] = read_little_endian<WeightType>(stream);
     return !stream.fail();
   }
 
+  // Write network parameters
   // パラメータを書き込む
   bool WriteParameters(std::ostream& stream) const {
     stream.write(reinterpret_cast<const char*>(biases_),
@@ -65,37 +135,52 @@ class FeatureTransformer {
     return !stream.fail();
   }
 
+  // Proceed with the difference calculation if possible
   // 可能なら差分計算を進める
   bool UpdateAccumulatorIfPossible(const Position& pos) const {
     const auto now = pos.state();
     if (now->accumulator.computed_accumulation) {
-      return true;
+        return true;
     }
     const auto prev = now->previous;
     if (prev && prev->accumulator.computed_accumulation) {
-      UpdateAccumulator(pos);
+      update_accumulator(pos);
       return true;
     }
     return false;
   }
 
+  // Convert input features
   // 入力特徴量を変換する
   void Transform(const Position& pos, OutputType* output, bool refresh) const {
     if (refresh || !UpdateAccumulatorIfPossible(pos)) {
-      RefreshAccumulator(pos);
+      refresh_accumulator(pos);
     }
     const auto& accumulation = pos.state()->accumulator.accumulation;
-#if defined(USE_AVX2)
+
+#if defined(USE_AVX512)
+    constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth * 2);
+    static_assert(kHalfDimensions % (kSimdWidth * 2) == 0);
+    const __m512i kControl = _mm512_setr_epi64(0, 2, 4, 6, 1, 3, 5, 7);
+    const __m512i kZero = _mm512_setzero_si512();
+
+#elif defined(USE_AVX2)
     constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
     constexpr int kControl = 0b11011000;
     const __m256i kZero = _mm256_setzero_si256();
 
-#elif defined(USE_SSSE3)
+#elif defined(USE_SSE2)
     constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
+#if defined(USE_SSE41)
     const __m128i kZero = _mm_setzero_si128();
-#if !defined(USE_SSE41) // SSE4非対応だがSSE3は使える環境
+#else // SSE41非対応だがSSE2は使える環境
     const __m128i k0x80s = _mm_set1_epi8(-128);
 #endif
+
+#elif defined(USE_MMX)
+    // USE_MMX を config.h では現状、有効化することがないので dead code
+    constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
+    const __m64 k0x80s = _mm_set1_pi8(-128);
 
 #elif defined(USE_NEON)
     constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
@@ -104,7 +189,18 @@ class FeatureTransformer {
     const Color perspectives[2] = {pos.side_to_move(), ~pos.side_to_move()};
     for (IndexType p = 0; p < 2; ++p) {
       const IndexType offset = kHalfDimensions * p;
-#if defined(USE_AVX2)
+#if defined(USE_AVX512)
+      auto out = reinterpret_cast<__m512i*>(&output[offset]);
+      for (IndexType j = 0; j < kNumChunks; ++j) {
+        __m512i sum0 = _mm512_load_si512(&reinterpret_cast<const __m512i*>(
+            accumulation[perspectives[p]][0])[j * 2 + 0]);
+        __m512i sum1 = _mm512_load_si512(&reinterpret_cast<const __m512i*>(
+            accumulation[perspectives[p]][0])[j * 2 + 1]);
+        _mm512_store_si512(&out[j], _mm512_permutexvar_epi64(kControl,
+            _mm512_max_epi8(_mm512_packs_epi16(sum0, sum1), kZero)));
+      }
+
+#elif defined(USE_AVX2)
       auto out = reinterpret_cast<__m256i*>(&output[offset]);
       for (IndexType j = 0; j < kNumChunks; ++j) {
         __m256i sum0 = _mm256_load_si256(&reinterpret_cast<const __m256i*>(
@@ -120,7 +216,8 @@ class FeatureTransformer {
         _mm256_store_si256(&out[j], _mm256_permute4x64_epi64(_mm256_max_epi8(
             _mm256_packs_epi16(sum0, sum1), kZero), kControl));
       }
-#elif defined(USE_SSSE3)
+
+#elif defined(USE_SSE2)
       auto out = reinterpret_cast<__m128i*>(&output[offset]);
       for (IndexType j = 0; j < kNumChunks; ++j) {
         __m128i sum0 = _mm_load_si128(&reinterpret_cast<const __m128i*>(
@@ -138,12 +235,24 @@ class FeatureTransformer {
         _mm_store_si128(&out[j],
 #if defined(USE_SSE41)
             _mm_max_epi8(packedbytes, kZero)
-#else // SSE4非対応だがSSE3は使える環境
+#else // SSE41非対応だがSSE2は使える環境
             _mm_subs_epi8(_mm_adds_epi8(packedbytes, k0x80s), k0x80s)
 #endif
         );
-
       }
+
+#elif defined(USE_MMX)
+      // USE_MMX を config.h では現状、有効化することがないので dead code
+      auto out = reinterpret_cast<__m64*>(&output[offset]);
+      for (IndexType j = 0; j < kNumChunks; ++j) {
+        __m64 sum0 = *(&reinterpret_cast<const __m64*>(
+            accumulation[perspectives[p]][0])[j * 2 + 0]);
+        __m64 sum1 = *(&reinterpret_cast<const __m64*>(
+            accumulation[perspectives[p]][0])[j * 2 + 1]);
+        const __m64 packedbytes = _mm_packs_pi16(sum0, sum1);
+        out[j] = _mm_subs_pi8(_mm_adds_pi8(packedbytes, k0x80s), k0x80s);
+      }
+
 #elif defined(USE_NEON)
       const auto out = reinterpret_cast<int8x8_t*>(&output[offset]);
       for (IndexType j = 0; j < kNumChunks; ++j) {
@@ -166,17 +275,23 @@ class FeatureTransformer {
       }
 #endif
     }
+#if defined(USE_MMX)
+    // USE_MMX を config.h では現状、有効化することがないので dead code
+    _mm_empty();
+#endif
   }
 
  private:
+  // Calculate cumulative value without using difference calculation
   // 差分計算を用いずに累積値を計算する
-  void RefreshAccumulator(const Position& pos) const {
+  void refresh_accumulator(const Position& pos) const {
     auto& accumulator = pos.state()->accumulator;
     for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
       Features::IndexList active_indices[2];
       RawFeatures::AppendActiveIndices(pos, kRefreshTriggers[i],
                                        active_indices);
-      for (const auto perspective : COLOR) {
+      for (Color perspective : { BLACK, WHITE }) {
+#if defined(VECTOR)
         if (i == 0) {
           std::memcpy(accumulator.accumulation[perspective][i], biases_,
                       kHalfDimensions * sizeof(BiasType));
@@ -186,64 +301,52 @@ class FeatureTransformer {
         }
         for (const auto index : active_indices[perspective]) {
           const IndexType offset = kHalfDimensions * index;
-#if defined(USE_AVX2)
-          auto accumulation = reinterpret_cast<__m256i*>(
+          auto accumulation = reinterpret_cast<vec_t*>(
               &accumulator.accumulation[perspective][i][0]);
-          auto column = reinterpret_cast<const __m256i*>(&weights_[offset]);
+          auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
           constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
           for (IndexType j = 0; j < kNumChunks; ++j) {
-            accumulation[j] = _mm256_add_epi16(accumulation[j], column[j]);
+            accumulation[j] = vec_add_16(accumulation[j], column[j]);
           }
-#elif defined(USE_SSE2)
-          auto accumulation = reinterpret_cast<__m128i*>(
-              &accumulator.accumulation[perspective][i][0]);
-          auto column = reinterpret_cast<const __m128i*>(&weights_[offset]);
-          constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
-          for (IndexType j = 0; j < kNumChunks; ++j) {
-            accumulation[j] = _mm_add_epi16(accumulation[j], column[j]);
-          }
-#elif defined(USE_NEON)
-          auto accumulation = reinterpret_cast<int16x8_t*>(
-              &accumulator.accumulation[perspective][i][0]);
-          auto column = reinterpret_cast<const int16x8_t*>(&weights_[offset]);
-          constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
-          for (IndexType j = 0; j < kNumChunks; ++j) {
-            accumulation[j] = vaddq_s16(accumulation[j], column[j]);
-          }
+        }
 #else
+        if (i == 0) {
+          std::memcpy(accumulator.accumulation[perspective][i], biases_,
+              kHalfDimensions * sizeof(BiasType));
+        } else {
+          std::memset(accumulator.accumulation[perspective][i], 0,
+              kHalfDimensions * sizeof(BiasType));
+        }
+        for (const auto index : active_indices[perspective]) {
+          const IndexType offset = kHalfDimensions * index;
+
           for (IndexType j = 0; j < kHalfDimensions; ++j) {
             accumulator.accumulation[perspective][i][j] += weights_[offset + j];
           }
-#endif
         }
+#endif
       }
     }
 
     accumulator.computed_accumulation = true;
+    // Stockfishでは fc27d15(2020-09-07) にcomputed_scoreが排除されているので確認
     accumulator.computed_score = false;
   }
 
+  // Calculate cumulative value using difference calculation
   // 差分計算を用いて累積値を計算する
-  void UpdateAccumulator(const Position& pos) const {
+  void update_accumulator(const Position& pos) const {
     const auto prev_accumulator = pos.state()->previous->accumulator;
     auto& accumulator = pos.state()->accumulator;
     for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
       Features::IndexList removed_indices[2], added_indices[2];
       bool reset[2];
       RawFeatures::AppendChangedIndices(pos, kRefreshTriggers[i],
-                                        removed_indices, added_indices, reset);
-      for (const auto perspective : COLOR) {
-#if defined(USE_AVX2)
+                removed_indices, added_indices, reset);
+      for (Color perspective : { BLACK, WHITE }) {
+#if defined(VECTOR)
         constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
-        auto accumulation = reinterpret_cast<__m256i*>(
-            &accumulator.accumulation[perspective][i][0]);
-#elif defined(USE_SSE2)
-        constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
-        auto accumulation = reinterpret_cast<__m128i*>(
-            &accumulator.accumulation[perspective][i][0]);
-#elif defined(USE_NEON)
-        constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
-        auto accumulation = reinterpret_cast<int16x8_t*>(
+        auto accumulation = reinterpret_cast<vec_t*>(
             &accumulator.accumulation[perspective][i][0]);
 #endif
         if (reset[perspective]) {
@@ -254,52 +357,36 @@ class FeatureTransformer {
             std::memset(accumulator.accumulation[perspective][i], 0,
                         kHalfDimensions * sizeof(BiasType));
           }
-        } else {  // 1から0に変化した特徴量に関する差分計算
+        } else {
+          // Difference calculation for the feature amount changed from 1 to 0
+          // 1から0に変化した特徴量に関する差分計算
           std::memcpy(accumulator.accumulation[perspective][i],
                       prev_accumulator.accumulation[perspective][i],
                       kHalfDimensions * sizeof(BiasType));
           for (const auto index : removed_indices[perspective]) {
             const IndexType offset = kHalfDimensions * index;
-#if defined(USE_AVX2)
-            auto column = reinterpret_cast<const __m256i*>(&weights_[offset]);
+#if defined(VECTOR)
+            auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
             for (IndexType j = 0; j < kNumChunks; ++j) {
-              accumulation[j] = _mm256_sub_epi16(accumulation[j], column[j]);
-            }
-#elif defined(USE_SSE2)
-            auto column = reinterpret_cast<const __m128i*>(&weights_[offset]);
-            for (IndexType j = 0; j < kNumChunks; ++j) {
-              accumulation[j] = _mm_sub_epi16(accumulation[j], column[j]);
-            }
-#elif defined(USE_NEON)
-            auto column = reinterpret_cast<const int16x8_t*>(&weights_[offset]);
-            for (IndexType j = 0; j < kNumChunks; ++j) {
-              accumulation[j] = vsubq_s16(accumulation[j], column[j]);
+              accumulation[j] = vec_sub_16(accumulation[j], column[j]);
             }
 #else
-            for (IndexType j = 0; j < kHalfDimensions; ++j) {
+          for (IndexType j = 0; j < kHalfDimensions; ++j) {
               accumulator.accumulation[perspective][i][j] -=
                   weights_[offset + j];
             }
 #endif
           }
         }
-        {  // 0から1に変化した特徴量に関する差分計算
+        {
+          // Difference calculation for features that changed from 0 to 1
+          // 0から1に変化した特徴量に関する差分計算
           for (const auto index : added_indices[perspective]) {
             const IndexType offset = kHalfDimensions * index;
-#if defined(USE_AVX2)
-            auto column = reinterpret_cast<const __m256i*>(&weights_[offset]);
+#if defined(VECTOR)
+            auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
             for (IndexType j = 0; j < kNumChunks; ++j) {
-              accumulation[j] = _mm256_add_epi16(accumulation[j], column[j]);
-            }
-#elif defined(USE_SSE2)
-            auto column = reinterpret_cast<const __m128i*>(&weights_[offset]);
-            for (IndexType j = 0; j < kNumChunks; ++j) {
-              accumulation[j] = _mm_add_epi16(accumulation[j], column[j]);
-            }
-#elif defined(USE_NEON)
-            auto column = reinterpret_cast<const int16x8_t*>(&weights_[offset]);
-            for (IndexType j = 0; j < kNumChunks; ++j) {
-              accumulation[j] = vaddq_s16(accumulation[j], column[j]);
+              accumulation[j] = vec_add_16(accumulation[j], column[j]);
             }
 #else
             for (IndexType j = 0; j < kHalfDimensions; ++j) {
@@ -313,26 +400,28 @@ class FeatureTransformer {
     }
 
     accumulator.computed_accumulation = true;
+    // Stockfishでは fc27d15(2020-09-07) にcomputed_scoreが排除されているので確認
     accumulator.computed_score = false;
   }
 
+  // parameter type
   // パラメータの型
   using BiasType = std::int16_t;
   using WeightType = std::int16_t;
 
+  // Make the learning class a friend
   // 学習用クラスをfriendにする
   friend class Trainer<FeatureTransformer>;
 
+  // parameter
   // パラメータ
   alignas(kCacheLineSize) BiasType biases_[kHalfDimensions];
   alignas(kCacheLineSize)
       WeightType weights_[kHalfDimensions * kInputDimensions];
-};
+};  // class FeatureTransformer
 
-}  // namespace NNUE
+}  // namespace Eval::NNUE
 
-}  // namespace Eval
+#endif // defined(EVAL_NNUE)
 
-#endif  // defined(EVAL_NNUE)
-
-#endif
+#endif // #ifndef NNUE_FEATURE_TRANSFORMER_H_INCLUDED

--- a/source/eval/nnue/nnue_feature_transformer.h
+++ b/source/eval/nnue/nnue_feature_transformer.h
@@ -12,7 +12,7 @@
 #include "nnue_architecture.h"
 #include "features/index_list.h"
 
-#include <cstring> // std::memset()
+#include <cstring>  // std::memset()
 
 namespace Eval::NNUE {
 
@@ -26,46 +26,47 @@ namespace Eval::NNUE {
 #if defined(USE_AVX512)
 typedef __m512i vec_t;
 #define vec_load(a) _mm512_load_si512(a)
-#define vec_store(a,b) _mm512_store_si512(a,b)
-#define vec_add_16(a,b) _mm512_add_epi16(a,b)
-#define vec_sub_16(a,b) _mm512_sub_epi16(a,b)
+#define vec_store(a, b) _mm512_store_si512(a, b)
+#define vec_add_16(a, b) _mm512_add_epi16(a, b)
+#define vec_sub_16(a, b) _mm512_sub_epi16(a, b)
 #define vec_zero _mm512_setzero_si512()
-static constexpr IndexType kNumRegs = 8; // only 8 are needed
+static constexpr IndexType kNumRegs = 8;  // only 8 are needed
 
 #elif defined(USE_AVX2)
 typedef __m256i vec_t;
 #define vec_load(a) _mm256_load_si256(a)
-#define vec_store(a,b) _mm256_store_si256(a,b)
-#define vec_add_16(a,b) _mm256_add_epi16(a,b)
-#define vec_sub_16(a,b) _mm256_sub_epi16(a,b)
+#define vec_store(a, b) _mm256_store_si256(a, b)
+#define vec_add_16(a, b) _mm256_add_epi16(a, b)
+#define vec_sub_16(a, b) _mm256_sub_epi16(a, b)
 #define vec_zero _mm256_setzero_si256()
 static constexpr IndexType kNumRegs = 16;
 
 #elif defined(USE_SSE2)
 typedef __m128i vec_t;
 #define vec_load(a) (*(a))
-#define vec_store(a,b) *(a)=(b)
-#define vec_add_16(a,b) _mm_add_epi16(a,b)
-#define vec_sub_16(a,b) _mm_sub_epi16(a,b)
+#define vec_store(a, b) *(a) = (b)
+#define vec_add_16(a, b) _mm_add_epi16(a, b)
+#define vec_sub_16(a, b) _mm_sub_epi16(a, b)
 #define vec_zero _mm_setzero_si128()
 static constexpr IndexType kNumRegs = Is64Bit ? 16 : 8;
 
 #elif defined(USE_MMX)
 typedef __m64 vec_t;
 #define vec_load(a) (*(a))
-#define vec_store(a,b) *(a)=(b)
-#define vec_add_16(a,b) _mm_add_pi16(a,b)
-#define vec_sub_16(a,b) _mm_sub_pi16(a,b)
+#define vec_store(a, b) *(a) = (b)
+#define vec_add_16(a, b) _mm_add_pi16(a, b)
+#define vec_sub_16(a, b) _mm_sub_pi16(a, b)
 #define vec_zero _mm_setzero_si64()
 static constexpr IndexType kNumRegs = 8;
 
 #elif defined(USE_NEON)
 typedef int16x8_t vec_t;
 #define vec_load(a) (*(a))
-#define vec_store(a,b) *(a)=(b)
-#define vec_add_16(a,b) vaddq_s16(a,b)
-#define vec_sub_16(a,b) vsubq_s16(a,b)
-#define vec_zero {0}
+#define vec_store(a, b) *(a) = (b)
+#define vec_add_16(a, b) vaddq_s16(a, b)
+#define vec_sub_16(a, b) vsubq_s16(a, b)
+#define vec_zero \
+	{ 0 }
 static constexpr IndexType kNumRegs = 16;
 
 #else
@@ -76,352 +77,327 @@ static constexpr IndexType kNumRegs = 16;
 // Input feature converter
 // 入力特徴量変換器
 class FeatureTransformer {
- private:
-  // Number of output dimensions for one side
-  // 片側分の出力の次元数
-  static constexpr IndexType kHalfDimensions = kTransformedFeatureDimensions;
+   private:
+	// Number of output dimensions for one side
+	// 片側分の出力の次元数
+	static constexpr IndexType kHalfDimensions = kTransformedFeatureDimensions;
 
 #if defined(VECTOR)
-  static constexpr IndexType kTileHeight = kNumRegs * sizeof(vec_t) / 2;
-  static_assert(kHalfDimensions % kTileHeight == 0, "kTileHeight must divide kHalfDimensions");
+	static constexpr IndexType kTileHeight = kNumRegs * sizeof(vec_t) / 2;
+	static_assert(kHalfDimensions % kTileHeight == 0, "kTileHeight must divide kHalfDimensions");
 #endif
 
- public:
-  // Output type
-  // 出力の型
-  using OutputType = TransformedFeatureType;
+   public:
+	// Output type
+	// 出力の型
+	using OutputType = TransformedFeatureType;
 
-  // Number of input/output dimensions
-  // 入出力の次元数
-  static constexpr IndexType kInputDimensions = RawFeatures::kDimensions;
-  static constexpr IndexType kOutputDimensions = kHalfDimensions * 2;
+	// Number of input/output dimensions
+	// 入出力の次元数
+	static constexpr IndexType kInputDimensions  = RawFeatures::kDimensions;
+	static constexpr IndexType kOutputDimensions = kHalfDimensions * 2;
 
-  // Size of forward propagation buffer
-  // 順伝播用バッファのサイズ
-  static constexpr std::size_t kBufferSize =
-      kOutputDimensions * sizeof(OutputType);
+	// Size of forward propagation buffer
+	// 順伝播用バッファのサイズ
+	static constexpr std::size_t kBufferSize = kOutputDimensions * sizeof(OutputType);
 
-  // Hash value embedded in the evaluation file
-  // 評価関数ファイルに埋め込むハッシュ値
-  static constexpr std::uint32_t GetHashValue() {
-    return RawFeatures::kHashValue ^ kOutputDimensions;
-  }
+	// Hash value embedded in the evaluation file
+	// 評価関数ファイルに埋め込むハッシュ値
+	static constexpr std::uint32_t GetHashValue() { return RawFeatures::kHashValue ^ kOutputDimensions; }
 
-  // A string that represents the structure
-  // 構造を表す文字列
-  static std::string GetStructureString() {
-    return RawFeatures::GetName() + "[" +
-        std::to_string(kInputDimensions) + "->" +
-        std::to_string(kHalfDimensions) + "x2]";
-  }
+	// A string that represents the structure
+	// 構造を表す文字列
+	static std::string GetStructureString() {
+		return RawFeatures::GetName() + "[" + std::to_string(kInputDimensions) + "->" +
+		       std::to_string(kHalfDimensions) + "x2]";
+	}
 
-  // Read network parameters
-  // パラメータを読み込む
-  bool ReadParameters(std::istream& stream) {
-    for (std::size_t i = 0; i < kHalfDimensions; ++i)
-      biases_[i] = read_little_endian<BiasType>(stream);
-    for (std::size_t i = 0; i < kHalfDimensions * kInputDimensions; ++i)
-      weights_[i] = read_little_endian<WeightType>(stream);
-    return !stream.fail();
-  }
+	// Read network parameters
+	// パラメータを読み込む
+	bool ReadParameters(std::istream& stream) {
+		for (std::size_t i = 0; i < kHalfDimensions; ++i) biases_[i] = read_little_endian<BiasType>(stream);
+		for (std::size_t i = 0; i < kHalfDimensions * kInputDimensions; ++i)
+			weights_[i] = read_little_endian<WeightType>(stream);
+		return !stream.fail();
+	}
 
-  // Write network parameters
-  // パラメータを書き込む
-  bool WriteParameters(std::ostream& stream) const {
-    stream.write(reinterpret_cast<const char*>(biases_),
-                 kHalfDimensions * sizeof(BiasType));
-    stream.write(reinterpret_cast<const char*>(weights_),
-                 kHalfDimensions * kInputDimensions * sizeof(WeightType));
-    return !stream.fail();
-  }
+	// Write network parameters
+	// パラメータを書き込む
+	bool WriteParameters(std::ostream& stream) const {
+		stream.write(reinterpret_cast<const char*>(biases_), kHalfDimensions * sizeof(BiasType));
+		stream.write(reinterpret_cast<const char*>(weights_), kHalfDimensions * kInputDimensions * sizeof(WeightType));
+		return !stream.fail();
+	}
 
-  // Proceed with the difference calculation if possible
-  // 可能なら差分計算を進める
-  bool UpdateAccumulatorIfPossible(const Position& pos) const {
-    const auto now = pos.state();
-    if (now->accumulator.computed_accumulation) {
-        return true;
-    }
-    const auto prev = now->previous;
-    if (prev && prev->accumulator.computed_accumulation) {
-      update_accumulator(pos);
-      return true;
-    }
-    return false;
-  }
+	// Proceed with the difference calculation if possible
+	// 可能なら差分計算を進める
+	bool UpdateAccumulatorIfPossible(const Position& pos) const {
+		const auto now = pos.state();
+		if (now->accumulator.computed_accumulation) {
+			return true;
+		}
+		const auto prev = now->previous;
+		if (prev && prev->accumulator.computed_accumulation) {
+			update_accumulator(pos);
+			return true;
+		}
+		return false;
+	}
 
-  // Convert input features
-  // 入力特徴量を変換する
-  void Transform(const Position& pos, OutputType* output, bool refresh) const {
-    if (refresh || !UpdateAccumulatorIfPossible(pos)) {
-      refresh_accumulator(pos);
-    }
-    const auto& accumulation = pos.state()->accumulator.accumulation;
+	// Convert input features
+	// 入力特徴量を変換する
+	void Transform(const Position& pos, OutputType* output, bool refresh) const {
+		if (refresh || !UpdateAccumulatorIfPossible(pos)) {
+			refresh_accumulator(pos);
+		}
+		const auto& accumulation = pos.state()->accumulator.accumulation;
 
 #if defined(USE_AVX512)
-    constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth * 2);
-    static_assert(kHalfDimensions % (kSimdWidth * 2) == 0);
-    const __m512i kControl = _mm512_setr_epi64(0, 2, 4, 6, 1, 3, 5, 7);
-    const __m512i kZero = _mm512_setzero_si512();
+		constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth * 2);
+		static_assert(kHalfDimensions % (kSimdWidth * 2) == 0);
+		const __m512i kControl = _mm512_setr_epi64(0, 2, 4, 6, 1, 3, 5, 7);
+		const __m512i kZero    = _mm512_setzero_si512();
 
 #elif defined(USE_AVX2)
-    constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
-    constexpr int kControl = 0b11011000;
-    const __m256i kZero = _mm256_setzero_si256();
+		constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
+		constexpr int       kControl   = 0b11011000;
+		const __m256i       kZero      = _mm256_setzero_si256();
 
 #elif defined(USE_SSE2)
-    constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
+		constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
 #if defined(USE_SSE41)
-    const __m128i kZero = _mm_setzero_si128();
-#else // SSE41非対応だがSSE2は使える環境
-    const __m128i k0x80s = _mm_set1_epi8(-128);
+		const __m128i kZero = _mm_setzero_si128();
+#else  // SSE41非対応だがSSE2は使える環境
+		const __m128i k0x80s = _mm_set1_epi8(-128);
 #endif
 
 #elif defined(USE_MMX)
-    // USE_MMX を config.h では現状、有効化することがないので dead code
-    constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
-    const __m64 k0x80s = _mm_set1_pi8(-128);
+		// USE_MMX を config.h では現状、有効化することがないので dead code
+		constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
+		const __m64         k0x80s     = _mm_set1_pi8(-128);
 
 #elif defined(USE_NEON)
-    constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
-    const int8x8_t kZero = {0};
+		constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
+		const int8x8_t      kZero      = {0};
 #endif
-    const Color perspectives[2] = {pos.side_to_move(), ~pos.side_to_move()};
-    for (IndexType p = 0; p < 2; ++p) {
-      const IndexType offset = kHalfDimensions * p;
+		const Color perspectives[2] = {pos.side_to_move(), ~pos.side_to_move()};
+		for (IndexType p = 0; p < 2; ++p) {
+			const IndexType offset = kHalfDimensions * p;
 #if defined(USE_AVX512)
-      auto out = reinterpret_cast<__m512i*>(&output[offset]);
-      for (IndexType j = 0; j < kNumChunks; ++j) {
-        __m512i sum0 = _mm512_load_si512(&reinterpret_cast<const __m512i*>(
-            accumulation[perspectives[p]][0])[j * 2 + 0]);
-        __m512i sum1 = _mm512_load_si512(&reinterpret_cast<const __m512i*>(
-            accumulation[perspectives[p]][0])[j * 2 + 1]);
-        _mm512_store_si512(&out[j], _mm512_permutexvar_epi64(kControl,
-            _mm512_max_epi8(_mm512_packs_epi16(sum0, sum1), kZero)));
-      }
+			auto out = reinterpret_cast<__m512i*>(&output[offset]);
+			for (IndexType j = 0; j < kNumChunks; ++j) {
+				__m512i sum0 =
+				    _mm512_load_si512(&reinterpret_cast<const __m512i*>(accumulation[perspectives[p]][0])[j * 2 + 0]);
+				__m512i sum1 =
+				    _mm512_load_si512(&reinterpret_cast<const __m512i*>(accumulation[perspectives[p]][0])[j * 2 + 1]);
+				_mm512_store_si512(&out[j], _mm512_permutexvar_epi64(
+				                                kControl, _mm512_max_epi8(_mm512_packs_epi16(sum0, sum1), kZero)));
+			}
 
 #elif defined(USE_AVX2)
-      auto out = reinterpret_cast<__m256i*>(&output[offset]);
-      for (IndexType j = 0; j < kNumChunks; ++j) {
-        __m256i sum0 = _mm256_load_si256(&reinterpret_cast<const __m256i*>(
-            accumulation[perspectives[p]][0])[j * 2 + 0]);
-        __m256i sum1 = _mm256_load_si256(&reinterpret_cast<const __m256i*>(
-            accumulation[perspectives[p]][0])[j * 2 + 1]);
-        for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
-          sum0 = _mm256_add_epi16(sum0, reinterpret_cast<const __m256i*>(
-              accumulation[perspectives[p]][i])[j * 2 + 0]);
-          sum1 = _mm256_add_epi16(sum1, reinterpret_cast<const __m256i*>(
-              accumulation[perspectives[p]][i])[j * 2 + 1]);
-        }
-        _mm256_store_si256(&out[j], _mm256_permute4x64_epi64(_mm256_max_epi8(
-            _mm256_packs_epi16(sum0, sum1), kZero), kControl));
-      }
+			auto out = reinterpret_cast<__m256i*>(&output[offset]);
+			for (IndexType j = 0; j < kNumChunks; ++j) {
+				__m256i sum0 =
+				    _mm256_load_si256(&reinterpret_cast<const __m256i*>(accumulation[perspectives[p]][0])[j * 2 + 0]);
+				__m256i sum1 =
+				    _mm256_load_si256(&reinterpret_cast<const __m256i*>(accumulation[perspectives[p]][0])[j * 2 + 1]);
+				for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
+					sum0 = _mm256_add_epi16(
+					    sum0, reinterpret_cast<const __m256i*>(accumulation[perspectives[p]][i])[j * 2 + 0]);
+					sum1 = _mm256_add_epi16(
+					    sum1, reinterpret_cast<const __m256i*>(accumulation[perspectives[p]][i])[j * 2 + 1]);
+				}
+				_mm256_store_si256(&out[j], _mm256_permute4x64_epi64(
+				                                _mm256_max_epi8(_mm256_packs_epi16(sum0, sum1), kZero), kControl));
+			}
 
 #elif defined(USE_SSE2)
-      auto out = reinterpret_cast<__m128i*>(&output[offset]);
-      for (IndexType j = 0; j < kNumChunks; ++j) {
-        __m128i sum0 = _mm_load_si128(&reinterpret_cast<const __m128i*>(
-            accumulation[perspectives[p]][0])[j * 2 + 0]);
-        __m128i sum1 = _mm_load_si128(&reinterpret_cast<const __m128i*>(
-            accumulation[perspectives[p]][0])[j * 2 + 1]);
-        for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
-          sum0 = _mm_add_epi16(sum0, reinterpret_cast<const __m128i*>(
-              accumulation[perspectives[p]][i])[j * 2 + 0]);
-          sum1 = _mm_add_epi16(sum1, reinterpret_cast<const __m128i*>(
-              accumulation[perspectives[p]][i])[j * 2 + 1]);
-        }
+			auto out = reinterpret_cast<__m128i*>(&output[offset]);
+			for (IndexType j = 0; j < kNumChunks; ++j) {
+				__m128i sum0 =
+				    _mm_load_si128(&reinterpret_cast<const __m128i*>(accumulation[perspectives[p]][0])[j * 2 + 0]);
+				__m128i sum1 =
+				    _mm_load_si128(&reinterpret_cast<const __m128i*>(accumulation[perspectives[p]][0])[j * 2 + 1]);
+				for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
+					sum0 = _mm_add_epi16(sum0,
+					                     reinterpret_cast<const __m128i*>(accumulation[perspectives[p]][i])[j * 2 + 0]);
+					sum1 = _mm_add_epi16(sum1,
+					                     reinterpret_cast<const __m128i*>(accumulation[perspectives[p]][i])[j * 2 + 1]);
+				}
 
-        const __m128i packedbytes = _mm_packs_epi16(sum0, sum1);
-        _mm_store_si128(&out[j],
+				const __m128i packedbytes = _mm_packs_epi16(sum0, sum1);
+				_mm_store_si128(&out[j],
 #if defined(USE_SSE41)
-            _mm_max_epi8(packedbytes, kZero)
-#else // SSE41非対応だがSSE2は使える環境
-            _mm_subs_epi8(_mm_adds_epi8(packedbytes, k0x80s), k0x80s)
+				                _mm_max_epi8(packedbytes, kZero)
+#else  // SSE41非対応だがSSE2は使える環境
+				                _mm_subs_epi8(_mm_adds_epi8(packedbytes, k0x80s), k0x80s)
 #endif
-        );
-      }
+				);
+			}
 
 #elif defined(USE_MMX)
-      // USE_MMX を config.h では現状、有効化することがないので dead code
-      auto out = reinterpret_cast<__m64*>(&output[offset]);
-      for (IndexType j = 0; j < kNumChunks; ++j) {
-        __m64 sum0 = *(&reinterpret_cast<const __m64*>(
-            accumulation[perspectives[p]][0])[j * 2 + 0]);
-        __m64 sum1 = *(&reinterpret_cast<const __m64*>(
-            accumulation[perspectives[p]][0])[j * 2 + 1]);
-        const __m64 packedbytes = _mm_packs_pi16(sum0, sum1);
-        out[j] = _mm_subs_pi8(_mm_adds_pi8(packedbytes, k0x80s), k0x80s);
-      }
+			// USE_MMX を config.h では現状、有効化することがないので dead code
+			auto out = reinterpret_cast<__m64*>(&output[offset]);
+			for (IndexType j = 0; j < kNumChunks; ++j) {
+				__m64       sum0 = *(&reinterpret_cast<const __m64*>(accumulation[perspectives[p]][0])[j * 2 + 0]);
+				__m64       sum1 = *(&reinterpret_cast<const __m64*>(accumulation[perspectives[p]][0])[j * 2 + 1]);
+				const __m64 packedbytes = _mm_packs_pi16(sum0, sum1);
+				out[j]                  = _mm_subs_pi8(_mm_adds_pi8(packedbytes, k0x80s), k0x80s);
+			}
 
 #elif defined(USE_NEON)
-      const auto out = reinterpret_cast<int8x8_t*>(&output[offset]);
-      for (IndexType j = 0; j < kNumChunks; ++j) {
-        int16x8_t sum = reinterpret_cast<const int16x8_t*>(
-            accumulation[perspectives[p]][0])[j];
-        for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
-          sum = vaddq_s16(sum, reinterpret_cast<const int16x8_t*>(
-              accumulation[perspectives[p]][i])[j]);
-        }
-        out[j] = vmax_s8(vqmovn_s16(sum), kZero);
-      }
+			const auto out = reinterpret_cast<int8x8_t*>(&output[offset]);
+			for (IndexType j = 0; j < kNumChunks; ++j) {
+				int16x8_t sum = reinterpret_cast<const int16x8_t*>(accumulation[perspectives[p]][0])[j];
+				for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
+					sum = vaddq_s16(sum, reinterpret_cast<const int16x8_t*>(accumulation[perspectives[p]][i])[j]);
+				}
+				out[j] = vmax_s8(vqmovn_s16(sum), kZero);
+			}
 #else
-      for (IndexType j = 0; j < kHalfDimensions; ++j) {
-        BiasType sum = accumulation[perspectives[p]][0][j];
-        for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
-          sum += accumulation[perspectives[p]][i][j];
-        }
-        output[offset + j] = static_cast<OutputType>(
-            std::max<int>(0, std::min<int>(127, sum)));
-      }
+			for (IndexType j = 0; j < kHalfDimensions; ++j) {
+				BiasType sum = accumulation[perspectives[p]][0][j];
+				for (IndexType i = 1; i < kRefreshTriggers.size(); ++i) {
+					sum += accumulation[perspectives[p]][i][j];
+				}
+				output[offset + j] = static_cast<OutputType>(std::max<int>(0, std::min<int>(127, sum)));
+			}
 #endif
-    }
+		}
 #if defined(USE_MMX)
-    // USE_MMX を config.h では現状、有効化することがないので dead code
-    _mm_empty();
+		// USE_MMX を config.h では現状、有効化することがないので dead code
+		_mm_empty();
 #endif
-  }
+	}
 
- private:
-  // Calculate cumulative value without using difference calculation
-  // 差分計算を用いずに累積値を計算する
-  void refresh_accumulator(const Position& pos) const {
-    auto& accumulator = pos.state()->accumulator;
-    for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
-      Features::IndexList active_indices[2];
-      RawFeatures::AppendActiveIndices(pos, kRefreshTriggers[i],
-                                       active_indices);
-      for (Color perspective : { BLACK, WHITE }) {
+   private:
+	// Calculate cumulative value without using difference calculation
+	// 差分計算を用いずに累積値を計算する
+	void refresh_accumulator(const Position& pos) const {
+		auto& accumulator = pos.state()->accumulator;
+		for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
+			Features::IndexList active_indices[2];
+			RawFeatures::AppendActiveIndices(pos, kRefreshTriggers[i], active_indices);
+			for (Color perspective : {BLACK, WHITE}) {
 #if defined(VECTOR)
-        if (i == 0) {
-          std::memcpy(accumulator.accumulation[perspective][i], biases_,
-                      kHalfDimensions * sizeof(BiasType));
-        } else {
-          std::memset(accumulator.accumulation[perspective][i], 0,
-                      kHalfDimensions * sizeof(BiasType));
-        }
-        for (const auto index : active_indices[perspective]) {
-          const IndexType offset = kHalfDimensions * index;
-          auto accumulation = reinterpret_cast<vec_t*>(
-              &accumulator.accumulation[perspective][i][0]);
-          auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
-          constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
-          for (IndexType j = 0; j < kNumChunks; ++j) {
-            accumulation[j] = vec_add_16(accumulation[j], column[j]);
-          }
-        }
+				if (i == 0) {
+					std::memcpy(accumulator.accumulation[perspective][i], biases_, kHalfDimensions * sizeof(BiasType));
+				} else {
+					std::memset(accumulator.accumulation[perspective][i], 0, kHalfDimensions * sizeof(BiasType));
+				}
+				for (const auto index : active_indices[perspective]) {
+					const IndexType offset = kHalfDimensions * index;
+					auto accumulation      = reinterpret_cast<vec_t*>(&accumulator.accumulation[perspective][i][0]);
+					auto column            = reinterpret_cast<const vec_t*>(&weights_[offset]);
+					constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
+					for (IndexType j = 0; j < kNumChunks; ++j) {
+						accumulation[j] = vec_add_16(accumulation[j], column[j]);
+					}
+				}
 #else
-        if (i == 0) {
-          std::memcpy(accumulator.accumulation[perspective][i], biases_,
-              kHalfDimensions * sizeof(BiasType));
-        } else {
-          std::memset(accumulator.accumulation[perspective][i], 0,
-              kHalfDimensions * sizeof(BiasType));
-        }
-        for (const auto index : active_indices[perspective]) {
-          const IndexType offset = kHalfDimensions * index;
+				if (i == 0) {
+					std::memcpy(accumulator.accumulation[perspective][i], biases_, kHalfDimensions * sizeof(BiasType));
+				} else {
+					std::memset(accumulator.accumulation[perspective][i], 0, kHalfDimensions * sizeof(BiasType));
+				}
+				for (const auto index : active_indices[perspective]) {
+					const IndexType offset = kHalfDimensions * index;
 
-          for (IndexType j = 0; j < kHalfDimensions; ++j) {
-            accumulator.accumulation[perspective][i][j] += weights_[offset + j];
-          }
-        }
+					for (IndexType j = 0; j < kHalfDimensions; ++j) {
+						accumulator.accumulation[perspective][i][j] += weights_[offset + j];
+					}
+				}
 #endif
-      }
-    }
+			}
+		}
 
-    accumulator.computed_accumulation = true;
-    // Stockfishでは fc27d15(2020-09-07) にcomputed_scoreが排除されているので確認
-    accumulator.computed_score = false;
-  }
+		accumulator.computed_accumulation = true;
+		// Stockfishでは fc27d15(2020-09-07) にcomputed_scoreが排除されているので確認
+		accumulator.computed_score = false;
+	}
 
-  // Calculate cumulative value using difference calculation
-  // 差分計算を用いて累積値を計算する
-  void update_accumulator(const Position& pos) const {
-    const auto prev_accumulator = pos.state()->previous->accumulator;
-    auto& accumulator = pos.state()->accumulator;
-    for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
-      Features::IndexList removed_indices[2], added_indices[2];
-      bool reset[2];
-      RawFeatures::AppendChangedIndices(pos, kRefreshTriggers[i],
-                removed_indices, added_indices, reset);
-      for (Color perspective : { BLACK, WHITE }) {
+	// Calculate cumulative value using difference calculation
+	// 差分計算を用いて累積値を計算する
+	void update_accumulator(const Position& pos) const {
+		const auto prev_accumulator = pos.state()->previous->accumulator;
+		auto&      accumulator      = pos.state()->accumulator;
+		for (IndexType i = 0; i < kRefreshTriggers.size(); ++i) {
+			Features::IndexList removed_indices[2], added_indices[2];
+			bool                reset[2];
+			RawFeatures::AppendChangedIndices(pos, kRefreshTriggers[i], removed_indices, added_indices, reset);
+			for (Color perspective : {BLACK, WHITE}) {
 #if defined(VECTOR)
-        constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
-        auto accumulation = reinterpret_cast<vec_t*>(
-            &accumulator.accumulation[perspective][i][0]);
+				constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
+				auto accumulation              = reinterpret_cast<vec_t*>(&accumulator.accumulation[perspective][i][0]);
 #endif
-        if (reset[perspective]) {
-          if (i == 0) {
-            std::memcpy(accumulator.accumulation[perspective][i], biases_,
-                        kHalfDimensions * sizeof(BiasType));
-          } else {
-            std::memset(accumulator.accumulation[perspective][i], 0,
-                        kHalfDimensions * sizeof(BiasType));
-          }
-        } else {
-          // Difference calculation for the feature amount changed from 1 to 0
-          // 1から0に変化した特徴量に関する差分計算
-          std::memcpy(accumulator.accumulation[perspective][i],
-                      prev_accumulator.accumulation[perspective][i],
-                      kHalfDimensions * sizeof(BiasType));
-          for (const auto index : removed_indices[perspective]) {
-            const IndexType offset = kHalfDimensions * index;
+				if (reset[perspective]) {
+					if (i == 0) {
+						std::memcpy(accumulator.accumulation[perspective][i], biases_,
+						            kHalfDimensions * sizeof(BiasType));
+					} else {
+						std::memset(accumulator.accumulation[perspective][i], 0, kHalfDimensions * sizeof(BiasType));
+					}
+				} else {
+					// Difference calculation for the feature amount changed from 1 to 0
+					// 1から0に変化した特徴量に関する差分計算
+					std::memcpy(accumulator.accumulation[perspective][i], prev_accumulator.accumulation[perspective][i],
+					            kHalfDimensions * sizeof(BiasType));
+					for (const auto index : removed_indices[perspective]) {
+						const IndexType offset = kHalfDimensions * index;
 #if defined(VECTOR)
-            auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
-            for (IndexType j = 0; j < kNumChunks; ++j) {
-              accumulation[j] = vec_sub_16(accumulation[j], column[j]);
-            }
+						auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
+						for (IndexType j = 0; j < kNumChunks; ++j) {
+							accumulation[j] = vec_sub_16(accumulation[j], column[j]);
+						}
 #else
-          for (IndexType j = 0; j < kHalfDimensions; ++j) {
-              accumulator.accumulation[perspective][i][j] -=
-                  weights_[offset + j];
-            }
+						for (IndexType j = 0; j < kHalfDimensions; ++j) {
+							accumulator.accumulation[perspective][i][j] -= weights_[offset + j];
+						}
 #endif
-          }
-        }
-        {
-          // Difference calculation for features that changed from 0 to 1
-          // 0から1に変化した特徴量に関する差分計算
-          for (const auto index : added_indices[perspective]) {
-            const IndexType offset = kHalfDimensions * index;
+					}
+				}
+				{
+					// Difference calculation for features that changed from 0 to 1
+					// 0から1に変化した特徴量に関する差分計算
+					for (const auto index : added_indices[perspective]) {
+						const IndexType offset = kHalfDimensions * index;
 #if defined(VECTOR)
-            auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
-            for (IndexType j = 0; j < kNumChunks; ++j) {
-              accumulation[j] = vec_add_16(accumulation[j], column[j]);
-            }
+						auto column = reinterpret_cast<const vec_t*>(&weights_[offset]);
+						for (IndexType j = 0; j < kNumChunks; ++j) {
+							accumulation[j] = vec_add_16(accumulation[j], column[j]);
+						}
 #else
-            for (IndexType j = 0; j < kHalfDimensions; ++j) {
-              accumulator.accumulation[perspective][i][j] +=
-                  weights_[offset + j];
-            }
+						for (IndexType j = 0; j < kHalfDimensions; ++j) {
+							accumulator.accumulation[perspective][i][j] += weights_[offset + j];
+						}
 #endif
-          }
-        }
-      }
-    }
+					}
+				}
+			}
+		}
 
-    accumulator.computed_accumulation = true;
-    // Stockfishでは fc27d15(2020-09-07) にcomputed_scoreが排除されているので確認
-    accumulator.computed_score = false;
-  }
+		accumulator.computed_accumulation = true;
+		// Stockfishでは fc27d15(2020-09-07) にcomputed_scoreが排除されているので確認
+		accumulator.computed_score = false;
+	}
 
-  // parameter type
-  // パラメータの型
-  using BiasType = std::int16_t;
-  using WeightType = std::int16_t;
+	// parameter type
+	// パラメータの型
+	using BiasType   = std::int16_t;
+	using WeightType = std::int16_t;
 
-  // Make the learning class a friend
-  // 学習用クラスをfriendにする
-  friend class Trainer<FeatureTransformer>;
+	// Make the learning class a friend
+	// 学習用クラスをfriendにする
+	friend class Trainer<FeatureTransformer>;
 
-  // parameter
-  // パラメータ
-  alignas(kCacheLineSize) BiasType biases_[kHalfDimensions];
-  alignas(kCacheLineSize)
-      WeightType weights_[kHalfDimensions * kInputDimensions];
+	// parameter
+	// パラメータ
+	alignas(kCacheLineSize) BiasType biases_[kHalfDimensions];
+	alignas(kCacheLineSize) WeightType weights_[kHalfDimensions * kInputDimensions];
 };  // class FeatureTransformer
 
 }  // namespace Eval::NNUE
 
-#endif // defined(EVAL_NNUE)
+#endif  // defined(EVAL_NNUE)
 
-#endif // #ifndef NNUE_FEATURE_TRANSFORMER_H_INCLUDED
+#endif  // #ifndef NNUE_FEATURE_TRANSFORMER_H_INCLUDED


### PR DESCRIPTION
- nnue_feature_transformer.h に関しては、AVX512対応とコード整理程度です。これによる性能向上は手元の環境ではありませんでした。
- affine_transform.h に関しては、ほぼ Stockfish NNUE ( https://github.com/official-stockfish/Stockfish/blob/7615e3485e75c2f1715d372f7bb1f546738a5c76/src/nnue/layers/affine_transform.h )の `Propagate()` 関数  そのままです。これにより、手元の環境では0.5%～1%程度の性能向上が見込まれます。
- それ以外は、単にインデントと名前空間の整理のみです。

## bench結果

engine1: 本patch適用前
engine2: 本patch適用後

```
2020-11-28 19:40:43,164 OS: Windows
2020-11-28 19:40:43,165
cmd: 16384 1 19 default depth
engine1: E:\shogi\dev\YaneuraOu-v5.32.0+20201128b.android-windows\windows\NNUE\YaneuraOu_NNUE-tournament-clang++-zen2.exe
engine2: E:\shogi\dev\20201128-pr_nnue-build-windows\windows\NNUE\YaneuraOu_NNUE-tournament-clang++-zen2.exe
eval1: D:\shogi\eval\tanuki2018_nnue
eval2: D:\shogi\eval\tanuki2018_nnue
log: bench.log
loop: 10

run       base       test     diff
  1     769403     776874    +7471
  2     771273     776117    +4844
  3     770638     774865    +4227
  4     771655     775169    +3514
  5     771353     775715    +4362
  6     771067     775507    +4440
  7     771782     777649    +5867
  8     770813     775619    +4806
  9     771305     777245    +5940
 10     772642     777794    +5152
2020-11-28 19:57:58,938 

   time_e1  nodes_e1  nps_e1  time_e2  nodes_e2  nps_e2  nps_diff
0    48662  37440707  769403    48194  37440707  776874      7471
1    48544  37440707  771273    48241  37440707  776117      4844
2    48584  37440707  770638    48319  37440707  774865      4227
3    48520  37440707  771655    48300  37440707  775169      3514
4    48539  37440707  771353    48266  37440707  775715      4362
5    48557  37440707  771067    48279  37440707  775507      4440
6    48512  37440707  771782    48146  37440707  777649      5867
7    48573  37440707  770813    48272  37440707  775619      4806
8    48542  37440707  771305    48171  37440707  777245      5940
9    48458  37440707  772642    48137  37440707  777794      5152

          time_e1    nodes_e1      nps_e1     time_e2    nodes_e2      nps_e2    nps_diff
count          10          10          10          10          10          10          10
mean        48549    37440707      771193       48232    37440707      776255        5062
std            53           0         842          66           0        1057        1121
min         48458    37440707      769403       48137    37440707      774865        3514
25%         48525    37440707      770876       48177    37440707      775535        4382
50%         48543    37440707      771289       48254    37440707      775916        4825
75%         48569    37440707      771580       48277    37440707      777152        5688
max         48662    37440707      772642       48319    37440707      777794        7471

Result of 10 runs
==================
base           =     771193 +/- 842
test           =     776255 +/- 1057
diff           =      +5062 +/- 1121

speedup        = +0.0066
P(speedup > 0) = 1.0000

Vendor ID         : AuthenticAMD
CPU Name          : AMD Ryzen Threadripper 3970X 32-Core Processor
Microarchitecture : x86_64
```