### PR TITLE
- define templated mated_even_ply() : Avoid C++20 features

### DIFF
--- a/source/mate/mate_n_ply.cpp
+++ b/source/mate/mate_n_ply.cpp
@@ -159,7 +159,7 @@ namespace {
 					else
 						++curr;
 				}
-			
+
 			ASSERT_LV3(size() <= MaxCheckMoves);
 		}
 		size_t size() const { return static_cast<size_t>(last - moveList); }
@@ -247,6 +247,11 @@ namespace Mate {
 		return MOVE_NONE;
 	}
 
+	// mated_even_ply() 定義前の宣言。
+	// 明示的なテンプレート引数を持つ関数呼び出しで、事前に宣言されていない関数テンプレート名を使用することは、C++20 の拡張機能です。
+	template <bool GEN_ALL>
+	Move mated_even_ply(Position& pos, const int ply);
+
 	// mate_odd_ply()の王手がかかっているかをtemplateにしたやつ。
 	// ※　dlshogiのmateMoveInOddPlyReturnMove()を参考にさせていただいています。
 	// InCheck : 王手がかかっているか
@@ -325,7 +330,7 @@ namespace Mate {
 		return GEN_ALL ? (pos.in_check() ? mate_odd_ply<true,true >(pos, depth) : mate_odd_ply<false,true >(pos, depth))
 		               : (pos.in_check() ? mate_odd_ply<true,false>(pos, depth) : mate_odd_ply<false,false>(pos, depth));
 	}
-		
+
 	// 偶数手詰め
 	// 前提) 手番側が王手されていること。
 	// この関数は、その王手が、逃れられずに手番側が詰むのかを判定する。
@@ -355,7 +360,7 @@ namespace Mate {
 			// 手番側が逃れる指し手を見つけたか。
 			// これがtrueになった時は、その指し手で逃れているので、この関数はfalseを返す。
 			bool found_escape = false;
-			
+
 			// 千日手チェック
 			switch (pos.is_repetition(16)) {
 			case REPETITION_WIN:	  // この関数に与えられた局面から見て相手が勝ち = 詰みを逃れていない


### PR DESCRIPTION
MATE_ENGINE clang++ でのビルドの際に出る警告及びエラーの回避です。

```
mate/mate_n_ply.cpp:301:18: warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
                                found_mate = mated_even_ply<GEN_ALL>(pos, ply - 1) == MOVE_NONE /* 回避手がない == 詰み */;
                                             ^
mate/mate_n_ply.cpp:301:18: error: call to function 'mated_even_ply' that is neither visible in the template definition nor found by argument-dependent lookup
mate/mate_n_ply.cpp:326:38: note: in instantiation of function template specialization 'Mate::mate_odd_ply<true, false>' requested here
                               : (pos.in_check() ? mate_odd_ply<true,false>(pos, depth) : mate_odd_ply<false,false>(pos, depth));
                                                   ^
mate/mate_n_ply.cpp:336:7: note: 'mated_even_ply' should be declared prior to the call site or in the global namespace
        Move mated_even_ply(Position& pos, const int ply)
             ^
```