### PR TITLE
- bench.py: PvInterval 0

### DIFF
--- a/script/bench.py
+++ b/script/bench.py
@@ -57,6 +57,7 @@ class YOBench():
     rlines = ""
     child = pexpect.spawn(self.path) if platform.system() != "Windows" else pexpect.popen_spawn.PopenSpawn(self.path.replace("\\", "/"))
     child.sendline("setoption name EvalDir value %s" % self.eval)
+    child.sendline("setoption name PvInterval value %s" % 0)
     child.sendline("isready")
     child.expect(r"readyok\s*\n", 60)
     rlines += child.before.decode("cp932", errors="ignore")


### PR DESCRIPTION
bench.py 実行時、エンジンオプションで PvInterval 0 を指定します。
実行画面への影響は特に無い部分ですが、
ファイルに出力されるログからPVをする時に役立つ場合もあるかと思います。