### PR TITLE
- ORT_MKL に エンジンオプション InterOpNumThreads, IntraOpNumThreads を追加。

### DIFF
--- a/source/engine/dlshogi-engine/YaneuraOu_dlshogi_bridge.cpp
+++ b/source/engine/dlshogi-engine/YaneuraOu_dlshogi_bridge.cpp
@@ -131,6 +131,13 @@ void USI::extra_option(USI::OptionsMap& o)
     o["DNN_Batch_Size7"]             << USI::Option(0, 0, 65536);
     o["DNN_Batch_Size8"]             << USI::Option(0, 0, 65536);
 
+#if defined(ORT_MKL)
+	// nn_onnx_runtime.cpp の NNOnnxRuntime::load() で使用するオプション。 
+	// グラフ全体のスレッド数?（default値1）ORT_MKLでは効果が無いかもしれない。
+	o["InterOpNumThreads"]           << USI::Option(1, 1, 65536);
+	// ノード内の実行並列化の際のスレッド数設定（default値4、NNUE等でのThreads相当）
+	o["IntraOpNumThreads"]           << USI::Option(4, 1, 65536);
+#endif
 
     //(*this)["Const_Playout"]               = USIOption(0, 0, INT_MAX);
 	// →　Playout数固定。これはNodeLimitでできるので不要。

--- a/source/eval/deep/nn_onnx_runtime.cpp
+++ b/source/eval/deep/nn_onnx_runtime.cpp
@@ -11,6 +11,7 @@
 #else
 #include <cpu_provider_factory.h>
 #endif
+#include "../../usi.h"
 
 using namespace std;
 using namespace Tools;
@@ -23,6 +24,10 @@ namespace Eval::dlshogi
 		Ort::SessionOptions session_options;
 		session_options.DisableMemPattern();
 		session_options.SetExecutionMode(ORT_SEQUENTIAL);
+#if defined(ORT_MKL)
+		session_options.SetInterOpNumThreads((int)Options["InterOpNumThreads"]);
+		session_options.SetIntraOpNumThreads((int)Options["IntraOpNumThreads"]);
+#endif
 #if defined(ORT_DML)
 		Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_DML(session_options, gpu_id));
 #else


### PR DESCRIPTION
  InterOpNumThreadsはグラフ全体のスレッド数（default値1）、
  IntraOpNumThreadsはノード内の実行並列化の際のスレッド数設定（default値4）。
  使用スレッドを変更したい時は IntraOpNumThreads の設定値を変更する。
  InterOpNumThreads の効果はよく分からない。ORT_MKLでは効果無いかも。
  cf: https://tadaoyamaoka.hatenablog.com/entry/2020/06/06/190259
  TadaiYamaokaの日記 - 2020-06-06 - ONNX Runtimeを使ってみる その2(性能測定)

> なお、ONNX Runtimeのスレッド数の設定には、SetInterOpNumThreadsとSetIntraOpNumThreadsがあるが、前者はグラフ全体のスレッド数、後者はノード内の実行を並列化する際のスレッド数を設定する。
参考：https://github.com/microsoft/onnxruntime/issues/2177
SetInterOpNumThreadsの方も8に変えてみたが、処理時間に変化はなかった。

GPUを使わずCPUを使用する版で、使用するスレッド数を調節したいという要望に対応する事を目指したもので、ORT-MKLのビルドのみに影響があります。

開発環境のThreadripper3970Xの場合、本変更適用前のORT-MKLはおよそ64論理コア数の半分、32スレッド程度の使用率でした。
IntraOpNumThreads のオプション値を1に設定すれば、およそ1スレッド程度で動作、
IntraOpNumThreads のオプション値を論理コア数の0.75～1.0倍程度で設定すれば、およそCPUはフルロードに近い稼働率になると思われます。

InterOpNumThreads のオプションの方は、念の為に追加したという程度で、棋力への影響がどの程度あるのかどうかなども未検証です。全く効果が見込まれないのであれば、将来的には廃止して良いかもしれません。

参考バイナリ: https://github.com/mizar/YaneuraOu/releases/tag/v6.0.0%2B20210103b.deep

追記:

ORT-CPUのビルドについては、ORT-MKLと同様な方法でエンジンオプションにより動作スレッド数を調節出来る見込みが立たないため、現時点では対象外としました。ORT-CPUはOpenMPを有効としているため、 intra_op_num_threads オプションの影響を受けません。

cf: https://github.com/microsoft/onnxruntime/blob/master/docs/FAQ.md#how-do-i-force-single-threaded-execution-mode-in-ort-by-default-sessionrun-uses-all-the-computers-cores

> ## How do I force single threaded execution mode in ORT? By default, session.run() uses all the computer's cores. 
>
> To limit use to a single thread only:
> * If built with OpenMP, set the environment variable OMP_NUM_THREADS to 1. The default inter_op_num_threads in session options is already 1.  
> * If not built with OpenMP, set the session options intra_op_num_threads to 1. Do not change the default inter_op_num_threads (1).
>
> It's recommended to build onnxruntime without openmp if you only need single threaded execution. 
>
> This is supported in ONNX Runtime v1.3.0+
