### PR TITLE
- go ponder で、stopもしくはponderhitを待たずにbestmoveを返す事があった

### DIFF
--- a/source/engine/dlshogi-engine/YaneuraOu_dlshogi_bridge.cpp
+++ b/source/engine/dlshogi-engine/YaneuraOu_dlshogi_bridge.cpp
@@ -302,6 +302,26 @@ void MainThread::search()
 	Move ponderMove;
 	Move move = searcher.UctSearchGenmove(&rootPos, rootPos.sfen(),{}, ponderMove, start_threads);
 
+	// 定跡Hitした場合など、幾つかのケースで DlshogiSearcher::UctSearchGenmove() はすぐに結果を返す。
+	// go ponderでの探索の場合、bestmoveを返すのはstopもしくはponderhitを待たないとならない。
+
+	// 最大depth深さに到達したときに、ここまで実行が到達するが、
+	// まだThreads.stopが生じていない。しかし、ponder中や、go infiniteによる探索の場合、
+	// USI(UCI)プロトコルでは、"stop"や"ponderhit"コマンドをGUIから送られてくるまでbest moveを出力してはならない。
+	// それゆえ、単にここでGUIからそれらのいずれかのコマンドが送られてくるまで待つ。
+	// "stop"が送られてきたらThreads.stop == trueになる。
+	// "ponderhit"が送られてきたらThreads.ponder == falseになるので、それを待つ。(stopOnPonderhitは用いない)
+	// "go infinite"に対してはstopが送られてくるまで待つ。
+	// ちなみにStockfishのほう、ここのコードに長らく同期上のバグがあった。
+	// やねうら王のほうは、かなり早くからこの構造で書いていた。最近のStockfishではこの書き方に追随した。
+	while (!Threads.stop && (this->ponder || Search::Limits.infinite)) {
+		//	こちらの思考は終わっているわけだから、ある程度細かく待っても問題ない。
+		// (思考のためには計算資源を使っていないので。)
+		Tools::sleep(1);
+
+		// Stockfishのコード、ここ、busy waitになっているが、さすがにそれは良くないと思う。
+	}
+
 	sync_cout << "bestmove " << to_usi_string(move);
 
 	// USI_Ponderがtrueならば、bestmoveに続けて、ponderの指し手も出力する。


### PR DESCRIPTION
  DlshogiSearcher::UctSearchGenmove() は定跡Hitなど、幾つかの場合はstopやponderhitを待たずに値を返す。
  そのため、bestmoveを出力する前に、stopもしくはponderhitを待つ処理が別途必要。

  cf. http://shogidokoro.starfree.jp/usi.html
  > ponder
  >
  > これを使うときは、必ずgo ponderというように、goのすぐあとにponderを書くことになります。
  > ponderという言葉は、辞書では「熟考」と訳されていますが、思考ゲームにおいては、相手の手番中に次の手を考える「先読み」を意味します。
  > go ponderは、先読みを開始する合図となります。（先読みを開始すべき局面は、この前にpositionコマンドによって送られてきています。）
  > エンジンは、go ponderによって思考を開始する場合、GUI側から次のコマンド（stopまたはponderhit）が送られてくる前にbestmoveで指し手を返してはいけません。（たとえ、思考開始の時点で詰んでいるような場合であったとしてもです。）相手が手を指すと、それによってstopまたはponderhitが送られて来るので、それを待ってからbestmoveで指し手を返すことになります。（この辺の流れついては、後述する「対局における通信の具体例」を読んで下さい。）