### PR TITLE
- TensorRT: cudaSetDevice()

### DIFF
--- a/source/eval/deep/nn_tensorrt.cpp
+++ b/source/eval/deep/nn_tensorrt.cpp
@@ -79,6 +79,7 @@ namespace Eval::dlshogi
 		// Create host and device buffers
 		// host(GPU側)に同じだけメモリを確保しておいて、CPU側からそこに転送する。
 
+		cudaSetDevice(gpu_id);
 		checkCudaErrors(cudaMalloc((void**)&x1_dev, sizeof(NN_Input1)        * max_batch_size));
 		checkCudaErrors(cudaMalloc((void**)&x2_dev, sizeof(NN_Input2)        * max_batch_size));
 		checkCudaErrors(cudaMalloc((void**)&y1_dev, sizeof(NN_Output_Policy) * max_batch_size));
@@ -94,6 +95,7 @@ namespace Eval::dlshogi
 		// load()でメモリ確保を行った場合、inputBindings.size() == 4のはず。
 		if (inputBindings.size())
 		{
+			cudaSetDevice(gpu_id);
 			checkCudaErrors(cudaFree(x1_dev));
 			checkCudaErrors(cudaFree(x2_dev));
 			checkCudaErrors(cudaFree(y1_dev));
@@ -254,6 +256,7 @@ namespace Eval::dlshogi
 
 	void NNTensorRT::forward(const int batch_size, NN_Input1* x1, NN_Input2* x2, NN_Output_Policy* y1, NN_Output_Value* y2)
 	{
+		cudaSetDevice(gpu_id);
 		inputDims1.d[0] = batch_size;
 		inputDims2.d[0] = batch_size;
 		context->setBindingDimensions(0, inputDims1);


### PR DESCRIPTION
複数GPU環境、TensorRT版ふかうら王において、1番目のGPUしか使われていなかった件の修正案です。

dlshogiの場合、 `UctSearch.cpp` 内で `cudaSetDevice()` が呼び出されていましたが、ふかうら王ではこの `cudaSetDevice()` を呼び出している箇所が無さそうでした。
https://github.com/TadaoYamaoka/DeepLearningShogi/blob/master/usi/UctSearch.cpp#L302-L339

手元の環境で `UCT_Threads1 3 , UCT_Threads2 3 , DNN_Batch_Size1 256` として複数GPUを使う設定を行うと、序盤の局面では複数GPUを使って dlshogi とほぼ同等の 100kNPS 程度の探索が出来そうです。

(ponder無しでのテスト対局)
![image](https://user-images.githubusercontent.com/68691/103764657-39fe1480-505f-11eb-9e67-d542b55cbd98.png)
