### PR TITLE
deep: 複数デバイス検知周りの改善

### DIFF
--- a/source/engine/dlshogi-engine/YaneuraOu_dlshogi_bridge.cpp
+++ b/source/engine/dlshogi-engine/YaneuraOu_dlshogi_bridge.cpp
@@ -192,11 +192,15 @@ void Search::clear()
 		(int)Options["DNN_Batch_Size5"], (int)Options["DNN_Batch_Size6"], (int)Options["DNN_Batch_Size7"], (int)Options["DNN_Batch_Size8"]
 	};
 
+	// 対応デバイス数を取得する
+	int device_count = NN::get_device_count();
+
 	std::vector<int> thread_nums;
 	std::vector<int> policy_value_batch_maxsizes;
 	for (int i = 0; i < max_gpu; ++i)
 	{
-		thread_nums.push_back(new_thread[i]);
+		// 対応デバイス数以上のデバイスIDのスレッド数は 0 として扱う(デバイスの無効化)
+		thread_nums.push_back(i < device_count ? new_thread[i] : 0);
 		policy_value_batch_maxsizes.push_back(new_policy_value_batch_maxsize[i]);
 	}
 

--- a/source/engine/dlshogi-engine/YaneuraOu_dlshogi_bridge.cpp
+++ b/source/engine/dlshogi-engine/YaneuraOu_dlshogi_bridge.cpp
@@ -31,32 +31,32 @@ void USI::extra_option(USI::OptionsMap& o)
 	searcher.book.init(o);
 
 #if 0
-    (*this)["Book_File"]                   = USIOption("book.bin");
-    (*this)["Best_Book_Move"]              = USIOption(true);
-    (*this)["OwnBook"]                     = USIOption(false);
-    (*this)["Min_Book_Score"]              = USIOption(-3000, -ScoreInfinite, ScoreInfinite);
-    (*this)["USI_Ponder"]                  = USIOption(false);
-    (*this)["Stochastic_Ponder"]           = USIOption(true);
-    (*this)["Time_Margin"]                 = USIOption(1000, 0, INT_MAX);
-    (*this)["Mate_Root_Search"]            = USIOption(29, 0, 35);
-    (*this)["DfPn_Hash"]                   = USIOption(2048, 64, 4096); // DfPnハッシュサイズ
-    (*this)["DfPn_Min_Search_Millisecs"]   = USIOption(300, 0, INT_MAX);
+	(*this)["Book_File"]                   = USIOption("book.bin");
+	(*this)["Best_Book_Move"]              = USIOption(true);
+	(*this)["OwnBook"]                     = USIOption(false);
+	(*this)["Min_Book_Score"]              = USIOption(-3000, -ScoreInfinite, ScoreInfinite);
+	(*this)["USI_Ponder"]                  = USIOption(false);
+	(*this)["Stochastic_Ponder"]           = USIOption(true);
+	(*this)["Time_Margin"]                 = USIOption(1000, 0, INT_MAX);
+	(*this)["Mate_Root_Search"]            = USIOption(29, 0, 35);
+	(*this)["DfPn_Hash"]                   = USIOption(2048, 64, 4096); // DfPnハッシュサイズ
+	(*this)["DfPn_Min_Search_Millisecs"]   = USIOption(300, 0, INT_MAX);
 #endif
 
 #ifdef MAKE_BOOK
 	// 定跡を生成するときはPV出力は抑制したほうが良さげ。
-    o["PV_Interval"]                 << USI::Option(0, 0, INT_MAX);
-    o["Save_Book_Interval"]          << USI::Option(100, 0, INT_MAX);
+	o["PV_Interval"]                 << USI::Option(0, 0, INT_MAX);
+	o["Save_Book_Interval"]          << USI::Option(100, 0, INT_MAX);
 #else
-    o["PV_Interval"]                 << USI::Option(500, 0, INT_MAX);
+	o["PV_Interval"]                 << USI::Option(500, 0, INT_MAX);
 #endif // !MAKE_BOOK
 
-	o["UCT_NodeLimit"]				 << USI::Option(10000000, 100000, 1000000000); // UCTノードの上限
+	o["UCT_NodeLimit"]               << USI::Option(10000000, 100000, 1000000000); // UCTノードの上限
 	// デバッグ用のメッセージ出力の有無
 	o["DebugMessage"]                << USI::Option(false);
 
 	// ノードを再利用するか。
-    o["ReuseSubtree"]                << USI::Option(true);
+	o["ReuseSubtree"]                << USI::Option(true);
 
 	// 投了値 : 1000分率で
 	o["Resign_Threshold"]            << USI::Option(0, 0, 1000);
@@ -64,7 +64,7 @@ void USI::extra_option(USI::OptionsMap& o)
 	// 引き分けの時の値 : 1000分率で
 
 	o["Draw_Value_Black"]            << USI::Option(500, 0, 1000);
-    o["Draw_Value_White"]            << USI::Option(500, 0, 1000);
+	o["Draw_Value_White"]            << USI::Option(500, 0, 1000);
 
 	// これがtrueであるなら、root color(探索開始局面の手番)が後手なら、
 	//
@@ -85,36 +85,36 @@ void USI::extra_option(USI::OptionsMap& o)
 #if 0
 	// fpu_reductionの値を100分率で設定。
 	// c_fpu_reduction_rootは、rootでのfpu_reductionの値。
-    o["C_fpu_reduction"]             << USI::Option(27, 0, 100);
-    o["C_fpu_reduction_root"]        << USI::Option(0, 0, 100);
+	o["C_fpu_reduction"]             << USI::Option(27, 0, 100);
+	o["C_fpu_reduction_root"]        << USI::Option(0, 0, 100);
 
-    o["C_init"]                      << USI::Option(144, 0, 500);
-    o["C_base"]                      << USI::Option(28288, 10000, 100000);
-    o["C_init_root"]                 << USI::Option(116, 0, 500);
-    o["C_base_root"]                 << USI::Option(25617, 10000, 100000);
+	o["C_init"]                      << USI::Option(144, 0, 500);
+	o["C_base"]                      << USI::Option(28288, 10000, 100000);
+	o["C_init_root"]                 << USI::Option(116, 0, 500);
+	o["C_base_root"]                 << USI::Option(25617, 10000, 100000);
 
-    o["Softmax_Temperature"]         << USI::Option(174, 1, 500);
+	o["Softmax_Temperature"]         << USI::Option(174, 1, 500);
 #endif
 
 	// 各GPU用のDNNモデル名と、そのGPU用のUCT探索のスレッド数と、そのGPUに一度に何個の局面をまとめて評価(推論)を行わせるのか。
 	// GPUは最大で8個まで扱える。
 
-    o["UCT_Threads1"]                << USI::Option(4, 0, 256);
-    o["UCT_Threads2"]                << USI::Option(0, 0, 256);
-    o["UCT_Threads3"]                << USI::Option(0, 0, 256);
-    o["UCT_Threads4"]                << USI::Option(0, 0, 256);
-    o["UCT_Threads5"]                << USI::Option(0, 0, 256);
-    o["UCT_Threads6"]                << USI::Option(0, 0, 256);
-    o["UCT_Threads7"]                << USI::Option(0, 0, 256);
-    o["UCT_Threads8"]                << USI::Option(0, 0, 256);
-    o["DNN_Model1"]                  << USI::Option(R"(model.onnx)");
-    o["DNN_Model2"]                  << USI::Option("");
-    o["DNN_Model3"]                  << USI::Option("");
-    o["DNN_Model4"]                  << USI::Option("");
-    o["DNN_Model5"]                  << USI::Option("");
-    o["DNN_Model6"]                  << USI::Option("");
-    o["DNN_Model7"]                  << USI::Option("");
-    o["DNN_Model8"]                  << USI::Option("");
+	o["UCT_Threads1"]                << USI::Option(4, 0, 256);
+	o["UCT_Threads2"]                << USI::Option(0, 0, 256);
+	o["UCT_Threads3"]                << USI::Option(0, 0, 256);
+	o["UCT_Threads4"]                << USI::Option(0, 0, 256);
+	o["UCT_Threads5"]                << USI::Option(0, 0, 256);
+	o["UCT_Threads6"]                << USI::Option(0, 0, 256);
+	o["UCT_Threads7"]                << USI::Option(0, 0, 256);
+	o["UCT_Threads8"]                << USI::Option(0, 0, 256);
+	o["DNN_Model1"]                  << USI::Option(R"(model.onnx)");
+	o["DNN_Model2"]                  << USI::Option("");
+	o["DNN_Model3"]                  << USI::Option("");
+	o["DNN_Model4"]                  << USI::Option("");
+	o["DNN_Model5"]                  << USI::Option("");
+	o["DNN_Model6"]                  << USI::Option("");
+	o["DNN_Model7"]                  << USI::Option("");
+	o["DNN_Model8"]                  << USI::Option("");
 
 #if defined(ONNXRUNTIME)
 	// CPUを使っていることがあるので、default値、ちょっと少なめにしておく。
@@ -124,22 +124,22 @@ void USI::extra_option(USI::OptionsMap& o)
 	o["DNN_Batch_Size1"]             << USI::Option(128, 1, 1024);
 #endif
 	o["DNN_Batch_Size2"]             << USI::Option(0, 0, 65536);
-    o["DNN_Batch_Size3"]             << USI::Option(0, 0, 65536);
-    o["DNN_Batch_Size4"]             << USI::Option(0, 0, 65536);
-    o["DNN_Batch_Size5"]             << USI::Option(0, 0, 65536);
-    o["DNN_Batch_Size6"]             << USI::Option(0, 0, 65536);
-    o["DNN_Batch_Size7"]             << USI::Option(0, 0, 65536);
-    o["DNN_Batch_Size8"]             << USI::Option(0, 0, 65536);
+	o["DNN_Batch_Size3"]             << USI::Option(0, 0, 65536);
+	o["DNN_Batch_Size4"]             << USI::Option(0, 0, 65536);
+	o["DNN_Batch_Size5"]             << USI::Option(0, 0, 65536);
+	o["DNN_Batch_Size6"]             << USI::Option(0, 0, 65536);
+	o["DNN_Batch_Size7"]             << USI::Option(0, 0, 65536);
+	o["DNN_Batch_Size8"]             << USI::Option(0, 0, 65536);
 
 #if defined(ORT_MKL)
-	// nn_onnx_runtime.cpp の NNOnnxRuntime::load() で使用するオプション。 
+	// nn_onnx_runtime.cpp の NNOnnxRuntime::load() で使用するオプション。
 	// グラフ全体のスレッド数?（default値1）ORT_MKLでは効果が無いかもしれない。
 	o["InterOpNumThreads"]           << USI::Option(1, 1, 65536);
 	// ノード内の実行並列化の際のスレッド数設定（default値4、NNUE等でのThreads相当）
 	o["IntraOpNumThreads"]           << USI::Option(4, 1, 65536);
 #endif
 
-    //(*this)["Const_Playout"]               = USIOption(0, 0, INT_MAX);
+	//(*this)["Const_Playout"]               = USIOption(0, 0, INT_MAX);
 	// →　Playout数固定。これはNodeLimitでできるので不要。
 
 	// leaf nodeでの奇数手詰めルーチンを呼び出す時の手数
@@ -164,8 +164,8 @@ void Search::clear()
 	searcher.book.read_book();
 
 #if 0
-			// オプション設定
-			dfpn_min_search_millisecs = options["DfPn_Min_Search_Millisecs"];
+	// オプション設定
+	dfpn_min_search_millisecs = options["DfPn_Min_Search_Millisecs"];
 #endif
 
 	searcher.SetPvInterval((TimePoint)Options["PV_Interval"]);
@@ -277,23 +277,23 @@ void MainThread::search()
 
 	// ponder中であれば、呼び出し元で待機しなければならない。
 
-	// 最大depth深さに到達したときに、ここまで実行が到達するが、
-	// まだThreads.stopが生じていない。しかし、ponder中や、go infiniteによる探索の場合、
-	// USI(UCI)プロトコルでは、"stop"や"ponderhit"コマンドをGUIから送られてくるまでbest moveを出力してはならない。
-	// それゆえ、単にここでGUIからそれらのいずれかのコマンドが送られてくるまで待つ。
-	// "stop"が送られてきたらThreads.stop == trueになる。
-	// "ponderhit"が送られてきたらThreads.ponder == falseになるので、それを待つ。(stopOnPonderhitは用いない)
-	// "go infinite"に対してはstopが送られてくるまで待つ。
-	// ちなみにStockfishのほう、ここのコードに長らく同期上のバグがあった。
-	// やねうら王のほうは、かなり早くからこの構造で書いていた。最近のStockfishではこの書き方に追随した。
-	while (!Threads.stop && (this->ponder || Search::Limits.infinite))
-	{
-		//	こちらの思考は終わっているわけだから、ある程度細かく待っても問題ない。
-		// (思考のためには計算資源を使っていないので。)
-		Tools::sleep(1);
+		// 最大depth深さに到達したときに、ここまで実行が到達するが、
+		// まだThreads.stopが生じていない。しかし、ponder中や、go infiniteによる探索の場合、
+		// USI(UCI)プロトコルでは、"stop"や"ponderhit"コマンドをGUIから送られてくるまでbest moveを出力してはならない。
+		// それゆえ、単にここでGUIからそれらのいずれかのコマンドが送られてくるまで待つ。
+		// "stop"が送られてきたらThreads.stop == trueになる。
+		// "ponderhit"が送られてきたらThreads.ponder == falseになるので、それを待つ。(stopOnPonderhitは用いない)
+		// "go infinite"に対してはstopが送られてくるまで待つ。
+		// ちなみにStockfishのほう、ここのコードに長らく同期上のバグがあった。
+		// やねうら王のほうは、かなり早くからこの構造で書いていた。最近のStockfishではこの書き方に追随した。
+		while (!Threads.stop && (this->ponder || Search::Limits.infinite))
+		{
+			//	こちらの思考は終わっているわけだから、ある程度細かく待っても問題ない。
+			// (思考のためには計算資源を使っていないので。)
+			Tools::sleep(1);
 
-		// Stockfishのコード、ここ、busy waitになっているが、さすがにそれは良くないと思う。
-	}
+			// Stockfishのコード、ここ、busy waitになっているが、さすがにそれは良くないと思う。
+		}
 
 	sync_cout << "bestmove " << to_usi_string(move);
 

--- a/source/eval/deep/nn.cpp
+++ b/source/eval/deep/nn.cpp
@@ -39,6 +39,15 @@ namespace Eval::dlshogi
 #endif
 	}
 
+	// 使用可能なデバイス数を取得する。
+	int NN::get_device_count() {
+#if defined(ONNXRUNTIME)
+		return NNOnnxRuntime::get_device_count();
+#elif defined(TENSOR_RT)
+		return NNTensorRT::get_device_count();
+#endif
+	}
+
 	// モデルファイル名を渡すとそれに応じたNN派生クラスをbuildして返してくれる。デザパタで言うところのbuilder。
 	std::shared_ptr<NN> NN::build_nn(const std::string& model_path , int gpu_id , int batch_size)
 	{

--- a/source/eval/deep/nn.cpp
+++ b/source/eval/deep/nn.cpp
@@ -38,7 +38,7 @@ namespace Eval::dlshogi
 		checkCudaErrors(cudaFreeHost(ptr));
 #endif
 	}
-	
+
 	// モデルファイル名を渡すとそれに応じたNN派生クラスをbuildして返してくれる。デザパタで言うところのbuilder。
 	std::shared_ptr<NN> NN::build_nn(const std::string& model_path , int gpu_id , int batch_size)
 	{
@@ -63,7 +63,7 @@ namespace Eval::dlshogi
 		//	nn = std::make_unique<NNWideResnet10>();
 #endif
 
-		sync_cout << "info string Start loading the model file, path = " << model_path << sync_endl;
+		sync_cout << "info string Start loading the model file, path = " << model_path << ", gpu_id = " << gpu_id << ", batch_size = " << batch_size << sync_endl;
 		if (!nn)
 		{
 			sync_cout << "Error! : unknown model type." << sync_endl;

--- a/source/eval/deep/nn.h
+++ b/source/eval/deep/nn.h
@@ -27,6 +27,9 @@ namespace Eval::dlshogi
 		// モデルファイルの読み込み。
 		virtual Tools::Result load(const std::string& model_path, int gpu_id , int batch_size) = 0;
 
+		// 使用可能なデバイス数を取得する。
+		static int get_device_count();
+
 		// 現在のスレッドとGPUを紐付ける。
 		// ※　CUDAの場合、cudaSetDevice()を呼び出す。必ず、そのスレッドの探索開始時(forward()まで)に一度はこれを呼び出さないといけない。
 		virtual void set_device(int gpu_id) {};

--- a/source/eval/deep/nn_onnx_runtime.h
+++ b/source/eval/deep/nn_onnx_runtime.h
@@ -25,6 +25,9 @@ namespace Eval::dlshogi
 		// NNによる推論
 		virtual void forward(const int batch_size, NN_Input1* x1, NN_Input2* x2, NN_Output_Policy* y1, NN_Output_Value* y2);
 
+		// 使用可能なデバイス数を取得する。
+		static int get_device_count();
+
 	private:
 		Ort::Env env;
 		std::unique_ptr<Ort::Session> session;

--- a/source/eval/deep/nn_tensorrt.cpp
+++ b/source/eval/deep/nn_tensorrt.cpp
@@ -112,7 +112,9 @@ namespace Eval::dlshogi
 	// ※　CUDAの場合、cudaSetDevice()を呼び出す。必ず、そのスレッドの探索開始時(forward()まで)に一度はこれを呼び出さないといけない。
 	void NNTensorRT::set_device(int gpu_id)
 	{
-		cudaSetDevice(gpu_id);
+		// 存在しないCUDAデバイスに設定しようとした場合、例えば↓のようなエラーを起こす。
+		// Error! : Cuda failure , Error = invalid device ordinal
+		checkCudaErrors(cudaSetDevice(gpu_id));
 	}
 
 	// 初回のみビルドが必要。

--- a/source/eval/deep/nn_tensorrt.cpp
+++ b/source/eval/deep/nn_tensorrt.cpp
@@ -228,6 +228,8 @@ namespace Eval::dlshogi
 		checkCudaErrors(cudaGetDeviceProperties(&device_prop, gpu_id));
 		checkCudaErrors(cudaDeviceGetPCIBusId(pciBusId, cBufLen, gpu_id));
 
+		sync_cout << "info string gpu_id = " << gpu_id << ", device_name = " << device_prop.name << ", pci_bus_id = " << pciBusId << sync_endl;
+
 		// ファイル名 + "." + GPU_ID + "." + DEVICE_NAME + "." + PCI_BUS_ID + "." + MAX_BATCH_SIZE + ".serialized"
 		// GPU_ID は個体に固有・固定ではない。（構成変更時に限らず、リブートしたらIDが変わることもある）
 		// 複数のCUDAデバイスが存在した時、全てのCUDAデバイスが同一とは限らない。

--- a/source/eval/deep/nn_tensorrt.cpp
+++ b/source/eval/deep/nn_tensorrt.cpp
@@ -115,6 +115,13 @@ namespace Eval::dlshogi
 		}
 	}
 
+	// 使用可能なデバイス数を取得する。
+	int NNTensorRT::get_device_count() {
+		int device_count = 0;
+		checkCudaErrors(cudaGetDeviceCount(&device_count));
+		return device_count;
+	}
+
 	// 現在のスレッドとGPUを紐付ける。
 	// ※　CUDAの場合、cudaSetDevice()を呼び出す。必ず、そのスレッドの探索開始時(forward()まで)に一度はこれを呼び出さないといけない。
 	void NNTensorRT::set_device(int gpu_id)

--- a/source/eval/deep/nn_tensorrt.h
+++ b/source/eval/deep/nn_tensorrt.h
@@ -47,6 +47,9 @@ namespace Eval::dlshogi
 		// 推論
 		virtual void forward(const int batch_size, NN_Input1* x1, NN_Input2* x2, NN_Output_Policy* y1, NN_Output_Value* y2);
 
+		// 使用可能なデバイス数を取得する。
+		static int get_device_count();
+
 		// 現在のスレッドとGPUを紐付ける。
 		// ※　CUDAの場合、cudaSetDevice()を呼び出す。必ず、そのスレッドの探索開始時(forward()まで)に一度はこれを呼び出さないといけない。
 		virtual void set_device(int gpu_id);

--- a/source/props/YaneuraOuEdition-Deep-ORT-DML.props
+++ b/source/props/YaneuraOuEdition-Deep-ORT-DML.props
@@ -17,7 +17,7 @@
       <PreprocessorDefinitions>YANEURAOU_ENGINE_DEEP;ONNXRUNTIME;ORT_DML;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;DXGI.lib;D3D12.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
- deep/nn : モデル読込中の gpu_id, batchsize を出力
  出力する項目の追加。
- TensorRT : 存在しないCUDAデバイスを使おうとした時のエラー検知
  cudaSetDevice() した時のエラー検知、これだけだと存在しないデバイスのスレッド数を設定した場合にエンジンがエラーで落ちるだけなので、後述のコミットで緩和を試みています。
- TensorRT : cudaFree() の際、一時的に cudaMalloc() したデバイスに変更する
  https://github.com/yaneurao/YaneuraOu/commit/b2c38ec2f8d3b79f9e18ff3c76d2b70911533fc4 の補強、念の為、cudaFree()後に元のデバイスに戻るようにする。
- TensorRT: シリアライズ時、ファイル名に device_name, pci_bus_id を含める
  gpu_idが同じデバイスがずっと同じデバイスとは限らないため、ファイル名に device_name, pci_bus_id を含めて混同の可能性を薄める。
- TensorRT : info string gpu_id , device_name , pci_bus_id
  NNTensorRT::load_model() の際、gpu_id , device_name , pci_bus_id の情報を出力する。
- indent YaneuraOu_dlshogi_bridge.cpp
- deep : 対応デバイス数以上のIDに設定されたスレッド数を無視する
  対応デバイスの数を検知し、デバイス数以上のIDに設定されたスレッド数を無視する事で、設定の食い違いによるエラー落ちを軽減する試み。
  同じ設定で、8GPUでも2GPUでも1GPUでもそこそこ動く構成が出来るようにしたい。
  ORT_DMLはその影響で、D3D12へのライブラリ依存を追加。とは言え、DirectMLはそもそもDirectX12対応が必須なので…。（自分の環境でしかテストしていないので、特にORT_DML版の方は何か拙い部分があるかもしれません）
  cf. [Direct ML#minimum_requirements - onnx runtime](https://www.onnxruntime.ai/docs/reference/execution-providers/DirectML-ExecutionProvider.html#minimum-requirements)
  > The DirectML execution provider requires any DirectX 12 capable device. Almost all commercially-available graphics cards released in the last several years support DirectX 12. Examples of compatible hardware include:
  >
  > - NVIDIA Kepler (GTX 600 series) and above
  > - AMD GCN 1st Gen (Radeon HD 7000 series) and above
  > - Intel Haswell (4th-gen core) HD Integrated Graphics and above
  >
  > DirectML is compatible with Windows 10, version 1709 (10.0.16299; RS3, “Fall Creators Update”) and newer.

- TensorRT版: info string の出力例（将棋所デバッグウィンドウ）
![image](https://user-images.githubusercontent.com/68691/104090394-cc015980-52b9-11eb-963b-6cc2de490782.png)
- TensorRT版: シリアライズされたファイル名の例
![image](https://user-images.githubusercontent.com/68691/104090424-023ed900-52ba-11eb-9c5c-cc09c805c159.png)

