### PR TITLE
- Revert "- Makefile修正。evallearnを指定した時だけ関連ソースファイルをコンパイルするように。"

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -228,6 +228,10 @@ SOURCES  = \
 	timeman.cpp                                                                \
 	book/book.cpp                                                              \
 	book/apery_book.cpp                                                        \
+	book/makebook.cpp                                                          \
+	book/makebook2015.cpp                                                      \
+	book/makebook2019.cpp                                                      \
+	book/makebook2021.cpp                                                      \
 	extra/bitop.cpp                                                            \
 	extra/long_effect.cpp                                                      \
 	extra/sfen_packer.cpp                                                      \
@@ -243,19 +247,10 @@ SOURCES  = \
 	eval/material/evaluate_material.cpp                                        \
 	testcmd/mate_test_cmd.cpp                                                  \
 	testcmd/normal_test_cmd.cpp                                                \
-	testcmd/benchmark.cpp
-
-
-ifeq (,$(findstring evallearn,$@))
-	SOURCES  +=                                                                \
-		book/makebook.cpp                                                      \
-		book/makebook2015.cpp                                                  \
-		book/makebook2019.cpp                                                  \
-		book/makebook2021.cpp                                                  \
-		learn/learner.cpp                                                      \
-		learn/learning_tools.cpp                                               \
-		learn/multi_think.cpp
-endif
+	testcmd/benchmark.cpp                                                      \
+	learn/learner.cpp                                                          \
+	learn/learning_tools.cpp                                                   \
+	learn/multi_think.cpp
 
 ifeq ($(YANEURAOU_EDITION),YANEURAOU_ENGINE_KPPT)
 	SOURCES  +=                                                                \
@@ -371,13 +366,13 @@ endif
 
 
 # 開発用branch
-ifeq (,$(findstring dev,$(ENGINE_BRANCH)))
+ifeq ($(findstring dev,$(ENGINE_BRANCH)),dev)
 	# SuperSort使ってみよう。
 	CPPFLAGS += -DDEV_BRANCH
 endif
 
 # abe
-ifeq (,$(findstring abe,$(ENGINE_BRANCH)))
+ifeq ($(findstring abe,$(ENGINE_BRANCH)),abe)
 	CPPFLAGS += -DPV_OUTPUT_DRAW_ONLY -DFORCE_BIND_THIS_THREAD
 endif
 


### PR DESCRIPTION
This reverts commit 07eb26ca39726d68289b2ef3eb3cffb69ff4045d.

commit 07eb26ca39726d68289b2ef3eb3cffb69ff4045d には以下のような問題がありましたので、コミット内容の撤回が相当と見られます。

- `evallearn` ターゲット以外を指定した場合でも、 `book/makebook*.cpp`, `learn/*.cpp` はコンパイル対象から除外されるわけではない。
- `ENGINE_BRANCH` を指定していなくても、追加の `CPPFLAGS` ( `-DDEV_BRANCH -DPV_OUTPUT_DRAW_ONLY -DFORCE_BIND_THIS_THREAD` ) が指定されてしまう。

このうち後者の、追加CPPFLAGSが指定されていた影響により、以下の事象が起きているようです。

https://yaneuraou.yaneu.com/2021/01/01/yaneuraou-v600/#comment-161160

> いつも大変お世話になっております
v6.0.2以降nosseのShogiGUI、将棋所に登録できなくなりました
やねうら王のNNUEのnosse　v6.0.2、v6.0.3(v6.0.1まではOKです)
登録時のメッセージは
ShogiGUIは「エンジンの起動に失敗しました」、将棋所はだんまりでした
御多忙の中大変申し訳ございません
Mizarさんにお伝えしていただけると幸いです(お世話になっております)

TARGET_CPU=NO_SSE にてSegmentation faultが起きていたと見られるのは以下の部分です:

https://github.com/yaneurao/YaneuraOu/blob/bff7a10337605f83601aa3a04a6285cc6f66baf4/source/thread.cpp#L61

`-DPV_OUTPUT_DRAW_ONLY -DFORCE_BIND_THIS_THREAD` の指定に伴い、上記の箇所でsegfaultが発生していたと見られます。