### PR TITLE
NDK のバージョンを r21e にする

### DIFF
--- a/.github/workflows/ndk.yml
+++ b/.github/workflows/ndk.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       # https://developer.android.com/ndk/downloads?hl=ja#stable-downloads
-      - name: Setup Android NDK r21b
+      - name: Setup Android NDK r21e
         uses: nttld/setup-ndk@v1
         with:
-          ndk-version: r21b
+          ndk-version: r21e
 
       - name: Checkout own repository
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,10 +247,10 @@ jobs:
           - edition: USER_ENGINE
 
     steps:
-      - name: Setup Android NDK r21d
+      - name: Setup Android NDK r21e
         uses: nttld/setup-ndk@v1
         with:
-          ndk-version: r21d
+          ndk-version: r21e
 
       - name: Checkout own repository
         uses: actions/checkout@v2


### PR DESCRIPTION
LTS 最新版が 2021-01 リリースの r21e ですので、アップデートしましょう。動作未確認ですが、ビルドが通るのは確認済みです。
本リポジトリの Android のビルドが失敗しているのは、一時的エラーで、この pull request とは無関係です。