### PR TITLE
- モデル読み込み時の情報表示追加

### DIFF
--- a/source/engine/dlshogi-engine/dlshogi_searcher.cpp
+++ b/source/engine/dlshogi-engine/dlshogi_searcher.cpp
@@ -106,6 +106,8 @@ namespace dlshogi
 		// ※　GC処理が終わらなくて、全探索スレッドの終了を待つコードになっているから、bestmoveが返せないことがある。
 		Threads.set(total_thread_num + dfpn_thread_num + search_interruption_check_thread_num);
 
+		// モデルの読み込み
+		TimePoint tpmodelloadbegin = now();
 		for (int i = 0; i < max_gpu; i++) {
 			if (new_thread[i] > 0) {
 				int policy_value_batch_maxsize = policy_value_batch_maxsizes[i];
@@ -123,6 +125,8 @@ namespace dlshogi
 				search_groups[i].Initialize(path , new_thread[i],/* gpu_id = */i, policy_value_batch_maxsize);
 			}
 		}
+		TimePoint tpmodelloadend = now();
+		sync_cout << "info string All model files have been loaded. " << tpmodelloadend - tpmodelloadbegin << "ms." << sync_endl;
 
 		// ----------------------
 		// 探索スレッドとUctSearcherの紐付け

--- a/source/eval/deep/nn.cpp
+++ b/source/eval/deep/nn.cpp
@@ -78,7 +78,10 @@ namespace Eval::dlshogi
 			sync_cout << "Error! : read error , model path = " << model_path << sync_endl;
 			return nullptr;
 		}
-		sync_cout << "info string The model file has been loaded." << sync_endl;
+		sync_cout << "info string The model file has been loaded, path = " << model_path
+			<< ", gpu_id = " << gpu_id
+			<< ", batch_size = " << batch_size
+			<< sync_endl;
 
 		return nn;
 	}


### PR DESCRIPTION
特に、マルチGPU環境（Amazon EC2 p4d.24xlargeなど）において初期化処理の進行を分かりやすく表示します。
Amazon EC2 p4d.24xlarge の場合、GPU8個全てでモデル読み込みを終えるのにWCSC31の際には約90秒程度掛かっていたため、所要時間の情報表示は欲しいと思っています。