### PR TITLE
- r/w apery_book, AperyBook::init() to public

### DIFF
--- a/source/book/apery_book.h
+++ b/source/book/apery_book.h
@@ -32,28 +32,27 @@ using Key = uint64_t;
 using Score = int;
 
 struct AperyBookEntry {
-    Key key;
-    uint16_t fromToPro;
-    uint16_t count;
-    Score score;
+	Key key;
+	uint16_t fromToPro;
+	uint16_t count;
+	Score score;
 };
 
 class AperyBook {
 public:
-    explicit AperyBook(const std::string& filename);
-    const std::vector<AperyBookEntry>& get_entries(const Position& pos) const;
-    static Key bookKey(const Position& pos);
-    size_t size() const { return book_.size(); }
+	explicit AperyBook(const std::string& filename);
+	const std::vector<AperyBookEntry>& get_entries(const Position& pos) const;
+	static Key bookKey(const Position& pos);
+	size_t size() const { return book_.size(); }
+	static void init();
 
 private:
-    static void init();
+	std::vector<AperyBookEntry> empty_entries_;
+	std::unordered_map<Key, std::vector<AperyBookEntry>> book_;
 
-    std::vector<AperyBookEntry> empty_entries_;
-    std::unordered_map<Key, std::vector<AperyBookEntry>> book_;
-
-    static Key ZobPiece[PIECE_NB - 1][SQ_NB];
-    static Key ZobHand[PIECE_HAND_NB - 1][19];
-    static Key ZobTurn;
+	static Key ZobPiece[PIECE_NB - 1][SQ_NB];
+	static Key ZobHand[PIECE_HAND_NB - 1][19];
+	static Key ZobTurn;
 };
 
 }

--- a/source/book/book.cpp
+++ b/source/book/book.cpp
@@ -732,7 +732,9 @@ namespace Book
 		}
 	}
 
-	// Apery用定跡ファイルの読み込み
+	// Apery用定跡ファイルの読み込み（定跡コンバート用）
+	// ・Aperyの定跡ファイルはAperyBookで別途読み込んでいるため、read_apery_bookは定跡のコンバート専用。
+	// ・unreg_depth は定跡未登録の局面を再探索する深さ。デフォルト値1。
 	Tools::Result MemoryBook::read_apery_book(const std::string& filename, const int unreg_depth)
 	{
 		std::lock_guard<std::recursive_mutex> lock(mutex_);
@@ -836,7 +838,7 @@ namespace Book
 		return Tools::Result::Ok();
 	}
 
-	// Apery用定跡ファイルの書き出し
+	// Apery用定跡ファイルの書き出し（定跡コンバート用）
 	Tools::Result MemoryBook::write_apery_book(const std::string& filename)
 	{
 		std::lock_guard<std::recursive_mutex> lock(mutex_);

--- a/source/book/book.cpp
+++ b/source/book/book.cpp
@@ -760,6 +760,7 @@ namespace Book
 		function<void(Position&, int)> search = [&](Position& pos, int unreg_depth_current) {
 			const string sfen = pos.sfen();
 			if (unreg_depth == unreg_depth_current) {
+				// 探索済みチェック: 未登録局面の深掘り時は探索済みセットのメモリ消費量が溢れるのを防ぐため、ここではチェックしない
 				const string sfen_for_key = StringExtension::trim_number(sfen);
 				if (seen.count(sfen_for_key)) return;
 				seen.insert(sfen_for_key);
@@ -772,6 +773,7 @@ namespace Book
 				if (unreg_depth_current < 1) return;
 			} else {
 				if (unreg_depth != unreg_depth_current) {
+					// 探索済みチェック: 未登録局面の深堀り時は、登録局面にヒットした時のみここでチェックする
 					const string sfen_for_key = StringExtension::trim_number(sfen);
 
 					if (seen.count(sfen_for_key))

--- a/source/book/book.h
+++ b/source/book/book.h
@@ -162,12 +162,15 @@ namespace Book
 		// また、事前にis_ready()は呼び出されているものとする。
 		Tools::Result write_book(const std::string& filename /*, bool sort = false*/) const;
 
-		// [ASYNC] Aperyの定跡ファイルを読み込む
-		// ・この関数はread_bookの下請けとして存在する。外部から直接呼び出すのは定跡のコンバートの時ぐらい。
-		Tools::Result read_apery_book(const std::string& filename);
+		// [ASYNC] Aperyの定跡ファイルを読み込む（定跡コンバート用）
+		// ・Aperyの定跡ファイルはAperyBookで別途読み込んでいるため、read_apery_bookは定跡のコンバート専用。
+		Tools::Result read_apery_book(const std::string& filename, int unreg_depth = 1);
+
+		// [ASYNC] Aperyの定跡ファイルに書き出す（定跡コンバート用）
+		Tools::Result write_apery_book(const std::string& filename);
 
 		// --------------------------------------------------------------------------
-		//     以下のメンバは、普段は外部から普段は直接アクセスすべきではない 
+		//     以下のメンバは、普段は外部から普段は直接アクセスすべきではない
 		//
 		//   定跡を書き換えてwrite_book()で書き出すような作業を行なうときだけアクセスする。
 		// --------------------------------------------------------------------------

--- a/source/book/book.h
+++ b/source/book/book.h
@@ -164,6 +164,7 @@ namespace Book
 
 		// [ASYNC] Aperyの定跡ファイルを読み込む（定跡コンバート用）
 		// ・Aperyの定跡ファイルはAperyBookで別途読み込んでいるため、read_apery_bookは定跡のコンバート専用。
+		// ・unreg_depth は定跡未登録の局面を再探索する深さ。デフォルト値1。
 		Tools::Result read_apery_book(const std::string& filename, int unreg_depth = 1);
 
 		// [ASYNC] Aperyの定跡ファイルに書き出す（定跡コンバート用）

--- a/source/book/makebook2015.cpp
+++ b/source/book/makebook2015.cpp
@@ -126,9 +126,11 @@ namespace Book
 		bool book_sort = token == "sort";
 		// 定跡の変換
 		bool convert_from_apery = token == "convert_from_apery";
-		
+		// 定跡の変換
+		bool convert_to_apery = token == "convert_to_apery";
+
 		// いずれのコマンドでもないなら、このtokenのコマンドを自分は処理できない。
-		if (!(from_sfen || from_thinking || book_merge || book_sort || convert_from_apery))
+		if (!(from_sfen || from_thinking || book_merge || book_sort || convert_from_apery || convert_to_apery))
 			return 0;
 
 		if (from_sfen || from_thinking)
@@ -646,6 +648,15 @@ namespace Book
 			book.read_apery_book(book_src);
 
 			book.write_book(book_dst);
+		}
+		else if (convert_to_apery) {
+			MemoryBook book;
+			string book_src, book_dst;
+			is >> book_src >> book_dst;
+			cout << "convert book from " << book_src << " , write apery book to " << book_dst << endl;
+			book.read_book(book_src);
+
+			book.write_apery_book(book_dst);
 		}
 
 		return 1;


### PR DESCRIPTION
read_apery_book() が read_book() の下請けになっていた経緯は多分無い？
https://github.com/yaneurao/YaneuraOu/pull/23/files?w=1

旧Apery形式定跡の読み書き拡張です。

Apery形式定跡の読み込みは、未登録の局面があってもその1手先に登録局面が無いか探索するように拡張しています。（そのため、処理に掛かる時間は大幅に増えています）

Apery形式定跡の書き出しにはZobristハッシュの初期化が必要であったため、 AperyBook::init() は public に変更しています。