### PR TITLE
- dangling-else

### DIFF
--- a/source/engine/dlshogi-engine/dlshogi_searcher.cpp
+++ b/source/engine/dlshogi-engine/dlshogi_searcher.cpp
@@ -630,6 +630,7 @@ namespace dlshogi
 
 		// 終了時刻が確定しているなら、そこ以降の時刻であれば停止させないといけない。
 		if (s.time_manager.search_end)
+		{
 			if (elapsed_from_ponderhit >= s.time_manager.search_end)
 			{
 				// 終了予定時刻より時間が超過している。
@@ -640,6 +641,7 @@ namespace dlshogi
 				// 探索終了時刻は設定されているのでこれ以上、探索打ち切りの判定は不要。
 				return;
 			}
+		}
 
 		const Node* current_root = tree->GetCurrentHead();
 		const int child_num = current_root->child_num;


### PR DESCRIPTION
engine/dlshogi-engine/dlshogi_searcher.cpp:643:4: warning: add explicit braces to avoid dangling else [-Wdangling-else]
                        else {
                        ^
1 warning generated.

elseブロックを持つif文のすぐ外側で、中括弧を省略したif文を使用することはclang++にて警告が出るようです。