### PR TITLE
AMD Optimized BLISを使用するための変数を追加した

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -95,6 +95,9 @@ EXTRA_CPPFLAGS =
 # cf.【連載】評価関数を作ってみよう！その1 : http://yaneuraou.yaneu.com/2020/11/17/make-evaluate-function/
 MATERIAL_LEVEL = 1
 
+# evallearnで使用するBLASの種類を指定する。
+BLAS = OPENBLAS
+# BLAS = BLIS
 
 # === implementations ===
 
@@ -206,10 +209,19 @@ endif
 
 # NNUE評価関数 学習バイナリ用 OpenBLAS
 ifneq (,$(findstring YANEURAOU_ENGINE_NNUE,$(YANEURAOU_EDITION)))
-	BLAS = -DUSE_BLAS
-	BLAS_LDFLAGS = -lopenblas
-	ifeq ($(MSYSTEM),MINGW64)
-		BLAS += -I$(shell cygpath -aw /mingw64/include/OpenBLAS)
+	ifeq ($(BLAS),OPENBLAS)
+		BLAS_CPPFLAGS = -DUSE_BLAS
+		BLAS_LDFLAGS = -lopenblas
+		ifeq ($(MSYSTEM),MINGW64)
+			BLAS_CPPFLAGS += -I$(shell cygpath -aw /mingw64/include/OpenBLAS)
+		endif
+	endif
+
+	ifeq ($(BLAS),BLIS)
+		BLAS_CPPFLAGS = -DUSE_BLAS
+		BLAS_CPPFLAGS += -I$(shell cygpath -aw /usr/local/include/blis)
+		BLAS_LDFLAGS = -lblis.dll
+		BLAS_LDFLAGS += -L$(shell cygpath -aw /usr/local/lib)
 	endif
 endif
 
@@ -498,7 +510,7 @@ normal:
 
 # 学習用。openmp , openblasなどを有効にする。
 evallearn:
-	$(MAKE) CPPFLAGS='$(CPPFLAGS) $(OPENMP) $(BLAS) -DEVAL_LEARN' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
+	$(MAKE) CPPFLAGS='$(CPPFLAGS) $(OPENMP) $(BLAS_CPPFLAGS) -DEVAL_LEARN' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
 
 # トーナメント用
 tournament:
@@ -506,7 +518,7 @@ tournament:
 
 # 教師棋譜生成用(開発用なので非公開) // currently private
 gensfen:
-	$(MAKE) CPPFLAGS='$(CPPFLAGS) $(OPENMP) $(BLAS) -DEVAL_LEARN -DGENSFEN2019' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
+	$(MAKE) CPPFLAGS='$(CPPFLAGS) $(OPENMP) $(BLAS_CPPFLAGS) -DEVAL_LEARN -DGENSFEN2019' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
 
 
 #　とりあえずPGOはAVX2とSSE4.2専用


### PR DESCRIPTION
tanuki- 2021-09-03 AMD Optimizing CPU Libraries 実験結果 - Google ドキュメント https://docs.google.com/document/d/1c-5VxR_TWH3okgTN28mZznPjdB06wxV13JfWNx7pCkU/edit
AMD Ryzen Threadripper 3990X を用いた場合、 OpenBLAS に比べ、 4% 程度学習が高速になりました。