### PR TITLE
- TensorRT 8.2 EarlyAccess

### DIFF
--- a/.github/workflows/make-deep-ubuntu.yml
+++ b/.github/workflows/make-deep-ubuntu.yml
@@ -11,8 +11,8 @@ on:
 
 jobs:
   build-ubuntu:
-    # ubuntu-latest = ubuntu-18.04 => ubuntu-20.04
-    # https://github.com/actions/virtual-environments/issues/1816
+    # ubuntu-latest = ubuntu-20.04
+    # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
     # https://docs.github.com/ja/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/make-deep-ubuntu.yml
+++ b/.github/workflows/make-deep-ubuntu.yml
@@ -20,9 +20,15 @@ jobs:
       matrix:
         edition:
           - YANEURAOU_ENGINE_DEEP_TENSOR_RT
-        compiler: [clang++-13, clang++-12, clang++-11, g++-10]
-        target: [normal]
-        archcpu: [AVX2]
+        compiler:
+          - clang++-13
+          - clang++-12
+          - clang++-11
+          - g++-10
+        target:
+          - normal
+        archcpu:
+          - AVX2
 
     steps:
       - name: Checkout own repository

--- a/.github/workflows/make-deep-ubuntu.yml
+++ b/.github/workflows/make-deep-ubuntu.yml
@@ -21,10 +21,12 @@ jobs:
         edition:
           - YANEURAOU_ENGINE_DEEP_TENSOR_RT
         compiler:
+          - clang++-14
           - clang++-13
           - clang++-12
           - clang++-11
           - g++-10
+          - g++-11
         target:
           - normal
         archcpu:
@@ -58,6 +60,16 @@ jobs:
           sudo apt update
           sudo apt install g++-10
         if: ${{ matrix.compiler == 'g++-10' }}
+      - name: install g++-11
+        #
+        run: |
+          # sudo curl "https://keyserver.ubuntu.com/pks/lookup?search=0x1e9377a2ba9ef27f&op=get" -o /usr/share/keyrings/ubuntu-toolchain-r.gpg.asc
+          # echo "deb [signed-by=/usr/share/keyrings/ubuntu-toolchain-r.gpg.asc] http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test-focal.list
+          sudo cat /etc/apt/sources.list
+          sudo ls -R /etc/apt/sources.list.d
+          sudo apt update
+          sudo apt install g++-11
+        if: ${{ matrix.compiler == 'g++-11' }}
       - name: install clang-11
         # Ubuntu 20.04
         run: |
@@ -67,21 +79,33 @@ jobs:
           sudo apt install clang-11 libomp-11-dev
         if: ${{ matrix.compiler == 'clang++-11' }}
       - name: install clang-12
-        # Ubuntu 21.04 or LLVM APT
+        # Ubuntu 20.04 or LLVM APT
         run: |
-          wget https://apt.llvm.org/llvm.sh
-          sudo bash ./llvm.sh 12
           sudo cat /etc/apt/sources.list
           sudo ls -R /etc/apt/sources.list.d
+          sudo apt update
+          sudo apt install clang-12 libomp-12-dev
         if: ${{ matrix.compiler == 'clang++-12' }}
       - name: install clang-13
         # LLVM APT
         run: |
+          # Remove packages that conflict with clang-13 installation
+          sudo apt remove -y clang-10 lldb-10 lld-10 clang-format-10 clang-11 lldb-11 lld-11 clang-format-11 clang-12 lldb-12 lld-12 clang-format-12
+          sudo apt autoremove -y
+          # install clang-13
           wget https://apt.llvm.org/llvm.sh
           sudo bash ./llvm.sh 13
           sudo cat /etc/apt/sources.list
           sudo ls -R /etc/apt/sources.list.d
         if: ${{ matrix.compiler == 'clang++-13' }}
+      - name: install clang-14
+        # LLVM APT
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          sudo bash ./llvm.sh 14
+          sudo cat /etc/apt/sources.list
+          sudo ls -R /etc/apt/sources.list.d
+        if: ${{ matrix.compiler == 'clang++-14' }}
 
       - name: make
         run: ./main/script/build.sh -e ${{ matrix.edition }} -c ${{ matrix.compiler }} -t ${{ matrix.target }} -a ${{ matrix.archcpu }} -x "EXTRA_CPPFLAGS='-I/usr/local/cuda/include' EXTRA_LDFLAGS='-L/usr/local/cuda/lib64'"

--- a/.github/workflows/make-deep-ubuntu.yml
+++ b/.github/workflows/make-deep-ubuntu.yml
@@ -37,19 +37,18 @@ jobs:
           path: main
 
       - name: install CUDA, TensorRT
-        # ここではCUDAアプリケーションの開発環境用に、CUDAドライバーを含まない cuda-toolkit-11-3 をインストールしている。
-        # CUDAアプリケーションの実行環境用にセットアップする場合、 cuda-toolkit-11-3 の代わりに
-        # CUDAドライバーを含むメタパッケージ、 cuda-11-3 もしくは cuda をインストールする。
+        # ここではCUDAアプリケーションの開発環境用に、CUDAドライバーを含まない cuda-toolkit-11-4 をインストールしている。
+        # CUDAアプリケーションの実行環境用にセットアップする場合、 cuda-toolkit-11-4 の代わりに
+        # CUDAドライバーを含むメタパッケージ、 cuda-11-4 もしくは cuda をインストールする。
         # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#package-manager-metas
         run: |
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
-          sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
-          sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
-          echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" | sudo tee -a /etc/apt/sources.list
+          sudo curl "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin" -o /etc/apt/preferences.d/cuda-repository-pin-600
+          sudo curl "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub" -o /usr/share/keyrings/cuda.gpg.asc
+          echo "deb [signed-by=/usr/share/keyrings/cuda.gpg.asc] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" | sudo tee /etc/apt/sources.list.d/cuda.list &&\
           sudo cat /etc/apt/sources.list
           sudo ls -R /etc/apt/sources.list.d
           sudo apt update
-          sudo apt install cuda-toolkit-11-3 libnvinfer-dev libnvinfer-plugin-dev libnvonnxparsers-dev libnvparsers-dev
+          sudo apt install cuda-toolkit-11-4 libnvinfer-dev libnvinfer-plugin-dev libnvonnxparsers-dev libnvparsers-dev
 
       - name: install g++-10
         # Ubuntu 20.04

--- a/source/config.h
+++ b/source/config.h
@@ -792,7 +792,8 @@ constexpr bool pretty_jp = false;
 			#define EVAL_TYPE_NAME "ORT-" << EVAL_DEEP
 		#endif
 	#elif defined(TENSOR_RT)
-		#define EVAL_TYPE_NAME "TensorRT-" << EVAL_DEEP
+		#include "NvInferRuntimeCommon.h"
+		#define EVAL_TYPE_NAME "TensorRT" << NV_TENSORRT_VERSION << "-" << EVAL_DEEP
 	#endif
 
 #else

--- a/source/props/YaneuraOuEdition-Deep-TensorRT.props
+++ b/source/props/YaneuraOuEdition-Deep-TensorRT.props
@@ -27,5 +27,17 @@
     <BuildMacro Include="YaneuraOuDir">
       <Value>$(YaneuraOuDir)</Value>
     </BuildMacro>
+    <None Include="C:\TensorRT-7.2.3.4\lib\nvinfer.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="C:\TensorRT-7.2.3.4\lib\nvinfer_plugin.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
+    <None Include="C:\TensorRT-7.2.3.4\lib\nvonnxparser.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </None>
   </ItemGroup>
 </Project>

--- a/source/props/YaneuraOuEdition-Deep-TensorRT.props
+++ b/source/props/YaneuraOuEdition-Deep-TensorRT.props
@@ -9,8 +9,8 @@
     <OutDir>$(OutBaseDir)$(YaneuraOuDir)\</OutDir>
     <TargetName>$(ProjectName)-$(YaneuraOuTarget)</TargetName>
     <_PropertySheetDisplayName>YaneuraOuEdition-Deep-TensorRT</_PropertySheetDisplayName>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);C:\TensorRT-7.2.3.4\include;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1\include</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);C:\TensorRT-7.2.3.4\lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1\lib\x64</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);C:\TensorRT-8.2.0.6\include;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.4\include</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);C:\TensorRT-8.2.0.6\lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.4\lib\x64</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -27,15 +27,15 @@
     <BuildMacro Include="YaneuraOuDir">
       <Value>$(YaneuraOuDir)</Value>
     </BuildMacro>
-    <None Include="C:\TensorRT-7.2.3.4\lib\nvinfer.dll">
+    <None Include="C:\TensorRT-8.2.0.6\lib\nvinfer.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Visible>false</Visible>
     </None>
-    <None Include="C:\TensorRT-7.2.3.4\lib\nvinfer_plugin.dll">
+    <None Include="C:\TensorRT-8.2.0.6\lib\nvinfer_plugin.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Visible>false</Visible>
     </None>
-    <None Include="C:\TensorRT-7.2.3.4\lib\nvonnxparser.dll">
+    <None Include="C:\TensorRT-8.2.0.6\lib\nvonnxparser.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Visible>false</Visible>
     </None>


### PR DESCRIPTION
- `EVAL_TYPE_NAME` に TensorRT のバージョンを追加
- Deep_TensorRT for MSVC
  - ビルド時にTensorRTのdllを出力先にコピー（実行ファイルと同じディレクトリに置くことで、PATHに設定したTensorRTのdllよりも優先して読み込ませるため）
  - TensorRT 8.2 EarlyAccess : https://developer.nvidia.com/nvidia-tensorrt-download
  - CUDA 11.4 update 2 : https://developer.nvidia.com/cuda-downloads?target_os=Windows&target_arch=x86_64&target_version=10
- Deep_TensorRT for Ubuntu20.04 ( make-deep-ubuntu.yml )
  - cuda-toolkit-11-4 に変更
  - clang++-12, clang++-13 のインストール方法の変更
  - clang++-14, g++-11 でのビルドパターンの追加

TensorRT-8.2 では TensorRT-7.2 に比べ、1割ほどNPSが向上した例がありましたのでお試しください。