### PR TITLE
g++ & arm64 でビルドできない問題を修正

### DIFF
--- a/source/extra/bitop.h
+++ b/source/extra/bitop.h
@@ -35,7 +35,7 @@
 #include <arm_neon.h>
 #include <mm_malloc.h> // for _mm_alloc()
 #else
-#if defined (__GNUC__) 
+#if defined (__GNUC__) && !defined(__ARM_ARCH)
 #include <mm_malloc.h> // for _mm_alloc()
 #endif
 #endif


### PR DESCRIPTION
#199 の関連イシューです。

AWSにはGraviton2というARM Neoverse N1系のプロセッサが存在します。

https://www.arm.com/why-arm/partner-ecosystem/aws

```
$ lscpu
Architecture:        aarch64
Byte Order:          Little Endian
CPU(s):              4
On-line CPU(s) list: 0-3
Thread(s) per core:  1
Core(s) per socket:  4
Socket(s):           1
NUMA node(s):        1
Model:               1
BogoMIPS:            243.75
L1d cache:           64K
L1i cache:           64K
L2 cache:            1024K
L3 cache:            32768K
NUMA node0 CPU(s):   0-3
Flags:               fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs
```

`g++` でコンパイルすると `extra/bitop.h:39:10: fatal error: mm_malloc.h: No such file or directory` というエラーが発生しました。


```
$ git diff Makefile
diff --git a/source/Makefile b/source/Makefile
index 640c1ad..4128889 100644
--- a/source/Makefile
+++ b/source/Makefile
@@ -46,13 +46,13 @@ YANEURAOU_EDITION = YANEURAOU_ENGINE_NNUE

 #TARGET_CPU = AVX512VNNI
 #TARGET_CPU = AVX512
-TARGET_CPU = AVX2
+#TARGET_CPU = AVX2
 #TARGET_CPU = SSE42
 #TARGET_CPU = SSE41
 #TARGET_CPU = SSSE3
 #TARGET_CPU = SSE2
 #TARGET_CPU = NO_SSE
-#TARGET_CPU = OTHER
+TARGET_CPU = OTHER
 #TARGET_CPU = ZEN1
 #TARGET_CPU = ZEN2

@@ -64,8 +64,8 @@ DEBUG = OFF

 # 使用するコンパイラ (compiler)
 # ※ clangでコンパイルしたほうがgccより数%速いっぽい。
-#COMPILER = g++
-COMPILER = clang++
+COMPILER = g++
+#COMPILER = clang++

$ make
rm -f ../obj/main.o ../obj/types.o ../obj/bitboard.o ../obj/misc.o ../obj/movegen.o ../obj/position.o ../obj/usi.o ../obj/usi_option.o ../obj/thread.o ../obj/tt.o ../obj/movepick.o ../obj/timeman.o ../obj/book/book.o ../obj/book/apery_book.o ../obj/extra/bitop.o ../obj/extra/long_effect.o ../obj/extra/sfen_packer.o ../obj/extra/super_sort.o ../obj/mate/mate.o ../obj/mate/mate1ply_without_effect.o ../obj/mate/mate1ply_with_effect.o ../obj/mate/mate_solver.o ../obj/eval/evaluate_bona_piece.o ../obj/eval/evaluate.o ../obj/eval/evaluate_io.o ../obj/eval/evaluate_mir_inv_tools.o ../obj/eval/material/evaluate_material.o ../obj/testcmd/unit_test.o ../obj/testcmd/mate_test_cmd.o ../obj/testcmd/normal_test_cmd.o ../obj/testcmd/benchmark.o ../obj/book/makebook.o ../obj/book/makebook2015.o ../obj/book/makebook2019.o ../obj/book/makebook2021.o../obj/learn/learner.o ../obj/learn/learning_tools.o ../obj/learn/multi_think.o ../obj/eval/nnue/evaluate_nnue.o ../obj/eval/nnue/evaluate_nnue_learner.o ../obj/eval/nnue/nnue_test_command.o ../obj/eval/nnue/features/k.o ../obj/eval/nnue/features/p.o ../obj/eval/nnue/features/half_kp.o ../obj/eval/nnue/features/half_relative_kp.o ../obj/eval/nnue/features/half_kpe9.o ../obj/eval/nnue/features/pe9.o ../obj/engine/yaneuraou-engine/yaneuraou-search.o ../obj/main.d ../obj/types.d ../obj/bitboard.d ../obj/misc.d ../obj/movegen.d ../obj/position.d ../obj/usi.d ../obj/usi_option.d ../obj/thread.d ../obj/tt.d ../obj/movepick.d ../obj/timeman.d ../obj/book/book.d ../obj/book/apery_book.d ../obj/extra/bitop.d ../obj/extra/long_effect.d ../obj/extra/sfen_packer.d ../obj/extra/super_sort.d ../obj/mate/mate.d ../obj/mate/mate1ply_without_effect.d ../obj/mate/mate1ply_with_effect.d ../obj/mate/mate_solver.d ../obj/eval/evaluate_bona_piece.d ../obj/eval/evaluate.d ../obj/eval/evaluate_io.d ../obj/eval/evaluate_mir_inv_tools.d ../obj/eval/material/evaluate_material.d ../obj/testcmd/unit_test.d ../obj/testcmd/mate_test_cmd.d ../obj/testcmd/normal_test_cmd.d ../obj/testcmd/benchmark.d ../obj/book/makebook.d ../obj/book/makebook2015.d ../obj/book/makebook2019.d ../obj/book/makebook2021.d ../obj/learn/learner.d ../obj/learn/learning_tools.d ../obj/learn/multi_think.d ../obj/eval/nnue/evaluate_nnue.d ../obj/eval/nnue/evaluate_nnue_learner.d ../obj/eval/nnue/nnue_test_command.d ../obj/eval/nnue/features/k.d ../obj/eval/nnue/features/p.d ../obj/eval/nnue/features/half_kp.d ../obj/eval/nnue/features/half_relative_kp.d ../obj/eval/nnue/features/half_kpe9.d ../obj/eval/nnue/features/pe9.d ../obj/engine/yaneuraou-engine/yaneuraou-search.d ./YaneuraOu-by-gcc ../obj/main.gcda ../obj/types.gcda ../obj/bitboard.gcda ../obj/misc.gcda ../obj/movegen.gcda ../obj/position.gcda ../obj/usi.gcda ../obj/usi_option.gcda ../obj/thread.gcda ../obj/tt.gcda ../obj/movepick.gcda ../obj/timeman.gcda ../obj/book/book.gcda ../obj/book/apery_book.gcda ../obj/extra/bitop.gcda ../obj/extra/long_effect.gcda ../obj/extra/sfen_packer.gcda ../obj/extra/super_sort.gcda ../obj/mate/mate.gcda ../obj/mate/mate1ply_without_effect.gcda ../obj/mate/mate1ply_with_effect.gcda ../obj/mate/mate_solver.gcda ../obj/eval/evaluate_bona_piece.gcda ../obj/eval/evaluate.gcda ../obj/eval/evaluate_io.gcda ../obj/eval/evaluate_mir_inv_tools.gcda ../obj/eval/material/evaluate_material.gcda ../obj/testcmd/unit_test.gcda ../obj/testcmd/mate_test_cmd.gcda ../obj/testcmd/normal_test_cmd.gcda ../obj/testcmd/benchmark.gcda ../obj/book/makebook.gcda ../obj/book/makebook2015.gcda ../obj/book/makebook2019.gcda ../obj/book/makebook2021.gcda ../obj/learn/learner.gcda ../obj/learn/learning_tools.gcda ../obj/learn/multi_think.gcda ../obj/eval/nnue/evaluate_nnue.gcda ../obj/eval/nnue/evaluate_nnue_learner.gcda ../obj/eval/nnue/nnue_test_command.gcda ../obj/eval/nnue/features/k.gcda ../obj/eval/nnue/features/p.gcda ../obj/eval/nnue/features/half_kp.gcda ../obj/eval/nnue/features/half_relative_kp.gcda ../obj/eval/nnue/features/half_kpe9.gcda ../obj/eval/nnue/features/pe9.gcda ../obj/engine/yaneuraou-engine/yaneuraou-search.gcda
g++ -std=c++17 -fno-exceptions -fno-rtti -Wextra -Ofast -MMD -MP -fpermissive -DNDEBUG -D_LINUX -DUNICODE -DNO_EXCEPTIONS -DTARGET_CPU=\"OTHER\" -DNO_SSE -DYANEURAOU_ENGINE_NNUE -DTARGET_CPU=\"OTHER\"   -o ../obj/main.o -c main.cpp
In file included from types.h:17:0,
                 from misc.h:12,
                 from search.h:5,
                 from main.cpp:4:
extra/bitop.h:39:10: fatal error: mm_malloc.h: No such file or directory
 #include <mm_malloc.h> // for _mm_alloc()
          ^~~~~~~~~~~~~
compilation terminated.
make: *** [../obj/main.o] Error 1
```

clab/dynet#266 にも類似の報告があり、ARM 向けでは `mm_malloc.h` が存在しないのが原因のようです。

Ubuntu での例

- amd64 https://packages.ubuntu.com/hirsute/amd64/libgcc-10-dev/filelist `mm_malloc.h` あり
- arm64 https://packages.ubuntu.com/hirsute/arm64/libgcc-10-dev/filelist `mm_malloc.h` なし


else のフォールバックで `g++` かつ非ARMの場合のみ、 `mm_malloc.h` を利用するようにしました。

g++でのビルドの成功とbench コマンドの実行までは動作確認しました。

参考までに、デフォルトパラメーターでの graviton 2(c6g) と Intel(m6i) の  xlarge での bench 結果です。

```
$ ./YaneuraOu-by-gcc
isready
info string EvalDirectory = /home/ec2-user/src/YaneuraOu/source/eval
info string loading eval file : eval/nn.bin
info string read book file : book/standard_book.db
info string Error! : can't read file : book/standard_book.db
info string USI_Hash : Start clearing with 4 threads , Hash size =  16[MB]
info string USI_Hash : Finish clearing.
readyok
bench
info string USI_Hash : Start clearing with 1 threads , Hash size =  1024[MB]
info string USI_Hash : Finish clearing.
Benchmark
    hash    : 1024
    threads : 1
    limit   : time 15
    sfen    : default

...

===========================
Total time (ms) : 60018
Nodes searched  : 8252107
Nodes/second    : 137493
```

※水匠4改の nn.bin 利用時

Intel Ice Lake の [m6i.xlarge](https://www.intel.com/content/www/us/en/newsroom/news/intel-powers-latest-amazon-ec2-cloud-instances.html#gs.dv8n3f) の bench 結果です。
```
Total time (ms) : 55643
Nodes searched  : 64225953
Nodes/second    : 1154250
```

NPS は見なかったことにしますw

