### PR TITLE
- graviton2 build test

### DIFF
--- a/.github/workflows/make-deep-ubuntu.yml
+++ b/.github/workflows/make-deep-ubuntu.yml
@@ -89,6 +89,12 @@ jobs:
       - name: install clang-14
         # LLVM APT
         run: |
+          # Remove packages that conflict with clang-14 installation
+          sudo apt remove -y \
+          liblldb-10 libomp-10-dev libomp5-10 lldb-10 python3-lldb-10 \
+          liblldb-11 libomp-11-dev libomp5-11 lldb-11 python3-lldb-11 \
+          liblldb-12 libomp-12-dev libomp5-12 lldb-12 python3-lldb-12
+          # install clang-14
           wget https://apt.llvm.org/llvm.sh
           sudo bash ./llvm.sh 14
           sudo cat /etc/apt/sources.list

--- a/.github/workflows/make-mingw.yml
+++ b/.github/workflows/make-mingw.yml
@@ -28,17 +28,20 @@ jobs:
           - YANEURAOU_MATE_ENGINE
           - TANUKI_MATE_ENGINE
           - USER_ENGINE
-        compiler: [x86_64-w64-mingw32-g++-posix, i686-w64-mingw32-g++-posix]
-        target: ["normal,tournament", gensfen, evallearn]
+        compiler:
+          - x86_64-w64-mingw32-g++-posix
+          - i686-w64-mingw32-g++-posix
+        target:
+          - "normal,tournament"
+          - gensfen
+          - evallearn
         archcpu:
-          [
-            "AVX512VNNI,AVX512",
-            "AVX2,SSE42,SSE2",
-            "SSE41,SSSE3,OTHER",
-            "ZEN1,ZEN2",
-            "ZEN3,AVXVNNI",
-            "NO_SSE",
-          ]
+          - "AVX512VNNI,AVX512"
+          - "AVX2,SSE42,SSE2"
+          - "SSE41,SSSE3,OTHER"
+          - "ZEN1,ZEN2"
+          - "ZEN3,AVXVNNI"
+          - "NO_SSE"
         exclude:
           # NNUEの教師生成/機械学習ビルドにはBLASが必要だが、現状はUbuntuのMinGWでOpenBLASを扱えない
           # NNUE's machine learning build requires BLAS, but currently Ubuntu's MinGW cannot handle OpenBLAS

--- a/.github/workflows/make-msys2.yml
+++ b/.github/workflows/make-msys2.yml
@@ -27,14 +27,17 @@ jobs:
           - YANEURAOU_MATE_ENGINE
           - TANUKI_MATE_ENGINE
           - USER_ENGINE
-        compiler: [clang++, g++]
-        target: ["normal,tournament", gensfen, evallearn]
+        compiler:
+          - clang++
+          - g++
+        target:
+          - "normal,tournament"
+          - gensfen
+          - evallearn
         archcpu:
-          [
-            "AVX512VNNI,AVX512,AVX2,SSE42,SSE41,SSSE3,SSE2,ZEN1,ZEN2",
-            NO_SSE,
-            "ZEN3,AVXVNNI,OTHER",
-          ]
+          - "AVX512VNNI,AVX512,AVX2,SSE42,SSE41,SSSE3,SSE2,ZEN1,ZEN2"
+          - NO_SSE
+          - "ZEN3,AVXVNNI,OTHER"
         exclude:
           # 以下のエディションには機械学習の実装が存在しない
           # There is no machine learning implementation for the following editions

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -19,25 +19,23 @@ jobs:
     strategy:
       matrix:
         edition:
-          - YANEURAOU_ENGINE_NNUE
-          - YANEURAOU_ENGINE_NNUE_HALFKPE9
-          - YANEURAOU_ENGINE_NNUE_KP256
-          - YANEURAOU_ENGINE_KPPT
-          - YANEURAOU_ENGINE_KPP_KKPT
+          - "YANEURAOU_ENGINE_NNUE,YANEURAOU_ENGINE_NNUE_HALFKPE9,YANEURAOU_ENGINE_NNUE_KP256,YANEURAOU_ENGINE_KPPT,YANEURAOU_ENGINE_KPP_KKPT"
           - YANEURAOU_ENGINE_MATERIAL*
           - YANEURAOU_MATE_ENGINE
           - TANUKI_MATE_ENGINE
           - USER_ENGINE
-        compiler: [clang++-13, clang++-12, g++-10]
-        target: ["normal,tournament", gensfen, evallearn]
+        compiler:
+          - clang++-14
+          - clang++-12
+          - g++-10
+        target:
+          - "normal,tournament"
+          - gensfen
+          - evallearn
         archcpu:
-          [
-            "AVX512,AVX2,SSE42,SSE2",
-            "SSE41,SSSE3,OTHER,ZEN1",
-            "ZEN2,AVX512VNNI",
-            "ZEN3,AVXVNNI",
-            "NO_SSE",
-          ]
+          - "AVX512,AVX2,SSE42,SSE41,SSSE3,SSE2,OTHER,ZEN2,ZEN1,AVX512VNNI"
+          - "ZEN3,AVXVNNI"
+          - "NO_SSE"
         exclude:
           # 以下のエディションには機械学習の実装が存在しない
           # There is no machine learning implementation for the following editions
@@ -71,6 +69,12 @@ jobs:
           # Linux 32bit archcpu 向けのビルドは通常はしない
           # don't usually build for Linux 32bit archcpu
           - archcpu: NO_SSE
+        include:
+          # GRAVITON2
+          - edition: "YANEURAOU_ENGINE_NNUE,YANEURAOU_ENGINE_NNUE_HALFKPE9,YANEURAOU_ENGINE_NNUE_KP256,YANEURAOU_ENGINE_KPPT,YANEURAOU_ENGINE_KPP_KKPT,YANEURAOU_ENGINE_MATERIAL*,YANEURAOU_MATE_ENGINE,TANUKI_MATE_ENGINE,USER_ENGINE"
+            compiler: aarch64-linux-gnu-g++
+            target: "normal,tournament"
+            archcpu: GRAVITON2
 
     steps:
       - name: Checkout own repository
@@ -86,6 +90,14 @@ jobs:
           sudo apt update
           sudo apt install build-essential libopenblas-dev g++-8
         if: ${{ matrix.compiler == 'g++-8' }}
+      - name: install g++-9
+        # Ubuntu 20.04
+        run: |
+          sudo cat /etc/apt/sources.list
+          sudo ls -R /etc/apt/sources.list.d
+          sudo apt update
+          sudo apt install build-essential libopenblas-dev g++-9
+        if: ${{ matrix.compiler == 'g++-9' }}
       - name: install g++-10
         # Ubuntu 20.04
         run: |
@@ -94,6 +106,16 @@ jobs:
           sudo apt update
           sudo apt install build-essential libopenblas-dev g++-10
         if: ${{ matrix.compiler == 'g++-10' }}
+      - name: install g++-11
+        #
+        run: |
+          # sudo curl "https://keyserver.ubuntu.com/pks/lookup?search=0x1e9377a2ba9ef27f&op=get" -o /usr/share/keyrings/ubuntu-toolchain-r.gpg.asc
+          # echo "deb [signed-by=/usr/share/keyrings/ubuntu-toolchain-r.gpg.asc] http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test-focal.list
+          sudo cat /etc/apt/sources.list
+          sudo ls -R /etc/apt/sources.list.d
+          sudo apt update
+          sudo apt install build-essential libopenblas-dev g++-11
+        if: ${{ matrix.compiler == 'g++-11' }}
       - name: install clang-10
         # Ubuntu 18.04, Ubuntu 20.04
         run: |
@@ -111,25 +133,48 @@ jobs:
           sudo apt install build-essential libopenblas-dev clang-11 libomp-11-dev
         if: ${{ matrix.compiler == 'clang++-11' }}
       - name: install clang-12
-        # Ubuntu 21.04 or LLVM APT
+        # Ubuntu 20.04 or LLVM APT
         run: |
-          wget https://apt.llvm.org/llvm.sh
-          sudo bash ./llvm.sh 12
           sudo cat /etc/apt/sources.list
           sudo ls -R /etc/apt/sources.list.d
           sudo apt update
-          sudo apt install build-essential libopenblas-dev libomp-12-dev
+          sudo apt install build-essential libopenblas-dev clang-12 libomp-12-dev
         if: ${{ matrix.compiler == 'clang++-12' }}
       - name: install clang-13
         # LLVM APT
         run: |
+          # Remove packages that conflict with clang-13 installation
+          sudo apt remove -y \
+          liblldb-10 libomp-10-dev libomp5-10 lldb-10 python3-lldb-10 \
+          liblldb-11 libomp-11-dev libomp5-11 lldb-11 python3-lldb-11 \
+          liblldb-12 libomp-12-dev libomp5-12 lldb-12 python3-lldb-12
+          # install clang-13
           wget https://apt.llvm.org/llvm.sh
           sudo bash ./llvm.sh 13
+          sudo apt install build-essential libopenblas-dev clang-13 libomp-13-dev
           sudo cat /etc/apt/sources.list
           sudo ls -R /etc/apt/sources.list.d
-          sudo apt update
-          sudo apt install build-essential libopenblas-dev libomp-13-dev
         if: ${{ matrix.compiler == 'clang++-13' }}
+      - name: install clang-14
+        # LLVM APT
+        run: |
+          # Remove packages that conflict with clang-14 installation
+          sudo apt remove -y \
+          liblldb-10 libomp-10-dev libomp5-10 lldb-10 python3-lldb-10 \
+          liblldb-11 libomp-11-dev libomp5-11 lldb-11 python3-lldb-11 \
+          liblldb-12 libomp-12-dev libomp5-12 lldb-12 python3-lldb-12
+          # install clang-14
+          wget https://apt.llvm.org/llvm.sh
+          sudo bash ./llvm.sh 14
+          sudo apt install build-essential libopenblas-dev clang-14 libomp-14-dev
+          sudo cat /etc/apt/sources.list
+          sudo ls -R /etc/apt/sources.list.d
+        if: ${{ matrix.compiler == 'clang++-14' }}
+      - name: install aarch64-linux-gnu-g++
+        run: |
+          sudo apt update
+          sudo apt install crossbuild-essential-arm64
+        if: ${{ matrix.compiler == 'aarch64-linux-gnu-g++' }}
 
       - name: make
         run: ./main/script/build.sh -e ${{ matrix.edition }} -c ${{ matrix.compiler }} -t ${{ matrix.target }} -a ${{ matrix.archcpu }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,15 @@ jobs:
 
     strategy:
       matrix:
-        target: [normal, tournament, evallearn, gensfen]
+        target:
+          - normal
+          - tournament
+          - evallearn
+          - gensfen
         archcpu:
-          [
-            "ZEN2,ZEN1,AVX512VNNI,AVX512,AVX2,SSE42",
-            "SSE41,SSSE3,SSE2,NO_SSE",
-            "ZEN3,AVXVNNI,OTHER",
-          ]
+          - "ZEN2,ZEN1,AVX512VNNI,AVX512,AVX2,SSE42"
+          - "SSE41,SSSE3,SSE2,NO_SSE"
+          - "ZEN3,AVXVNNI,OTHER"
         edition:
           - "YANEURAOU_ENGINE_NNUE,YANEURAOU_ENGINE_NNUE_HALFKPE9,YANEURAOU_ENGINE_NNUE_KP256"
           - "YANEURAOU_ENGINE_KPPT,YANEURAOU_ENGINE_KPP_KKPT"
@@ -30,7 +32,9 @@ jobs:
           - YANEURAOU_MATE_ENGINE
           - TANUKI_MATE_ENGINE
           - USER_ENGINE
-        compiler: [clang++, g++]
+        compiler:
+          - clang++
+          - g++
         exclude:
           # Release target exclude: edition USER_ENGINE
           - edition: USER_ENGINE
@@ -108,19 +112,23 @@ jobs:
 
     strategy:
       matrix:
-        target: [normal, tournament, evallearn, gensfen]
+        target:
+          - normal
+          - tournament
+          - evallearn
+          - gensfen
         archcpu:
-          [
-            ZEN2,
-            ZEN1,
-            AVX2,
-            SSE42,
-            SSE2,
-            NO_SSE,
-          ]
+          - ZEN2
+          - ZEN1
+          - AVX2
+          - SSE42
+          - SSE2
+          - NO_SSE
         edition:
           - YANEURAOU_ENGINE_MATERIAL*
-        compiler: [clang++, g++]
+        compiler:
+          - clang++
+          - g++
         exclude:
           # Release target exclude: edition USER_ENGINE
           - edition: USER_ENGINE

--- a/script/build.sh
+++ b/script/build.sh
@@ -51,19 +51,20 @@ pushd `dirname $0`
 pushd ../source
 
 ARCHCPUS=(
+  ZEN1
+  ZEN2
+  ZEN3
   AVX512VNNI
-  AVX512
   AVXVNNI
+  AVX512
   AVX2
   SSE42
   SSE41
   SSSE3
   SSE2
   NO_SSE
+  GRAVITON2
   OTHER
-  ZEN1
-  ZEN2
-  ZEN3
 )
 
 EDITIONS=(

--- a/source/Makefile
+++ b/source/Makefile
@@ -484,7 +484,9 @@ else ifeq ($(TARGET_CPU),NO_SSE)
 	# MinGW-64の32bit環境用でコンパイルする必要がある。
 	CPPFLAGS += -DNO_SSE -m32 -march=pentium3
 else ifeq ($(TARGET_CPU),GRAVITON2)
-	CPPFLAGS += -DIS_64BIT -DUSE_NEON -mfpu=neon
+	# for Amazon Web Servece EC2, the Graviton2 CPU [M6g/M6gd, C6g/C6gd/C6gn, R6g/R6gd, T4g, X2gd] instances
+	# https://github.com/aws/aws-graviton-getting-started/blob/main/c-c++.md
+	CPPFLAGS += -DIS_64BIT -DUSE_NEON -march=armv8.2-a+fp16+rcpc+dotprod+crypto
 
 else ifeq ($(TARGET_CPU),OTHER)
 	CPPFLAGS += -DNO_SSE


### PR DESCRIPTION
- Graviton2 向けビルドテストを Ubuntu Linux 20.04 (amd64) 環境、 `aarch64-linux-gnu-g++-9` コンパイラにて行います。(`normal`, `tournament` target のみ)
- Graviton2 向けビルドオプションを `-mfpu=neon` から `-march=armv8.2-a+fp16+rcpc+dotprod+crypto` に変更します。（`-mfpu=neon` のままではビルドテストに失敗するため）
  - 変更元: https://github.com/yaneurao/YaneuraOu/pull/201
  - 参考: https://github.com/aws/aws-graviton-getting-started/blob/main/c-c++.md
  - 参考: https://d1.awsstatic.com/webinars/jp/pdf/services/20200707_BlackBelt_Graviton2.pdf
- Ubuntu Linux 20.04 (amd64) 環境でのビルドテストに使うコンパイラの一部を変更します。 `clang++-13` → `clang++-14`
  - 最新のclangで発生するwarning, error等を確認できるように。
- その他、ビルドマトリクスの整理など。