### PR TITLE
- cuda-11.4 の明示

### DIFF
--- a/.github/workflows/make-deep-ubuntu.yml
+++ b/.github/workflows/make-deep-ubuntu.yml
@@ -116,7 +116,7 @@ jobs:
           sudo apt install cuda-toolkit-11-4 libnvinfer-dev libnvinfer-plugin-dev libnvonnxparsers-dev libnvparsers-dev
 
       - name: make
-        run: ./main/script/build.sh -e ${{ matrix.edition }} -c ${{ matrix.compiler }} -t ${{ matrix.target }} -a ${{ matrix.archcpu }} -x "EXTRA_CPPFLAGS='-I/usr/local/cuda/include' EXTRA_LDFLAGS='-L/usr/local/cuda/lib64'"
+        run: ./main/script/build.sh -e ${{ matrix.edition }} -c ${{ matrix.compiler }} -t ${{ matrix.target }} -a ${{ matrix.archcpu }} -x "EXTRA_CPPFLAGS='-I/usr/local/cuda-11.4/include' EXTRA_LDFLAGS='-L/usr/local/cuda-11.4/lib64'"
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
- CUDA Toolkit 11.5 Downloads : https://developer.nvidia.com/cuda-downloads
- NVIDIA CUDA Toolkit Release Notes : https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html

CUDA Toolkit 11.5 のリリースに伴ってなのか、TensorRT版のビルドテストにおいてincludeファイルが見つからなくなるエラーが発生しているため、当面は `/usr/local/cuda/` ではなく、明示的に `/usr/local/cuda-11.4/` 以下を見るよう変更します。