### PR TITLE
- msys2 toolchain llvm-13, gcc-11.2 (add arch AVXVNNI, ZEN3)

### DIFF
--- a/.github/workflows/make-msys2.yml
+++ b/.github/workflows/make-msys2.yml
@@ -35,9 +35,9 @@ jobs:
           - gensfen
           - evallearn
         archcpu:
-          - "AVX512VNNI,AVX512,AVX2,SSE42,SSE41,SSSE3,SSE2,ZEN1,ZEN2"
+          - "AVX512VNNI,AVXVNNI,AVX512,AVX2,SSE42,SSE41,SSSE3,SSE2,ZEN1,ZEN2,ZEN3"
           - NO_SSE
-          - "ZEN3,AVXVNNI,OTHER"
+          - OTHER
         exclude:
           # 以下のエディションには機械学習の実装が存在しない
           # There is no machine learning implementation for the following editions
@@ -60,13 +60,13 @@ jobs:
           # Build check exclude: archcpu ZEN3,AVXVNNI,OTHER
           # `-march=cascadelake`: LLVM8, GCC9 support (AVX512VNNI)
           # `-march=alderlake` : LLVM12, GCC11 support (AVX-VNNI)
-          # `-march=znver3`: LLVM12 support
+          # `-march=znver3`: LLVM12, GCC11 support
           # https://llvm.org/docs/ReleaseNotes.html#changes-to-the-x86-target
           # https://gcc.gnu.org/gcc-11/changes.html#x86
           # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
           # https://gcc.gnu.org/pipermail/gcc-patches/2020-October/556110.html
           # https://twitter.com/herumi/status/1318418425295720448
-          - archcpu: "ZEN3,AVXVNNI,OTHER"
+          - archcpu: OTHER
           # NO_SSEではevallearn,gensfenビルドを除外
           - target: evallearn
             archcpu: NO_SSE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
           - evallearn
           - gensfen
         archcpu:
-          - "ZEN2,ZEN1,AVX512VNNI,AVX512,AVX2,SSE42"
+          - "ZEN3,ZEN2,ZEN1,AVX512VNNI,AVXVNNI,AVX512,AVX2,SSE42"
           - "SSE41,SSSE3,SSE2,NO_SSE"
-          - "ZEN3,AVXVNNI,OTHER"
+          - "OTHER"
         edition:
           - "YANEURAOU_ENGINE_NNUE,YANEURAOU_ENGINE_NNUE_HALFKPE9,YANEURAOU_ENGINE_NNUE_KP256"
           - "YANEURAOU_ENGINE_KPPT,YANEURAOU_ENGINE_KPP_KKPT"
@@ -51,8 +51,8 @@ jobs:
           # Release target exclude: archcpu ZEN3,AVXVNNI,OTHER
           # `-march=cascadelake`: LLVM8, GCC9 support (AVX512VNNI)
           # `-march=alderlake` : LLVM12, GCC11 support (AVX-VNNI)
-          # `-march=znver3`: LLVM12 support
-          - archcpu: "ZEN3,AVXVNNI,OTHER"
+          # `-march=znver3`: LLVM12, GCC11 support
+          - archcpu: "OTHER"
           # Release target exclude: archcpu 'SSE41,SSSE3,SSE2,NO_SSE' and target 'tournament,evallearn'
           - target: tournament
             archcpu: "SSE41,SSSE3,SSE2,NO_SSE"
@@ -118,6 +118,7 @@ jobs:
           - evallearn
           - gensfen
         archcpu:
+          - ZEN3
           - ZEN2
           - ZEN1
           - AVX2
@@ -416,15 +417,15 @@ jobs:
 
             - [${{ steps.version.outputs.filename }}-windows.zip](https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/${{ steps.version.outputs.filename }}-windows.zip) (${{ steps.archive_size.outputs.windows_zip }})
             - [${{ steps.version.outputs.filename }}-windows.7z](https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/${{ steps.version.outputs.filename }}-windows.7z) (${{ steps.archive_size.outputs.windows_7z }})
-              - 1.2.3.5.6.の実行ファイルWindows版 各CPU向け(ZEN2/ZEN1/AVX512VNNI/AVX512/AVX2/SSE4.2/SSE4.1/SSSE3/SSE2/32bit環境用)
-              - 1.2.3.5.6.のトーナメントWindows版 (ZEN2/ZEN1/AVX512VNNI/AVX512/AVX2/SSE4.2)
-              - 1.2.3.の教師生成用実行ファイルWindows版 (ZEN2/ZEN1/AVX512VNNI/AVX512/AVX2/SSE4.2)
-              - 1.2.3.の学習用実行ファイルWindows版 (ZEN2/ZEN1/AVX512VNNI/AVX512/AVX2/SSE4.2)
+              - 1.2.3.5.6.の実行ファイルWindows版 各CPU向け(ZEN3/ZEN2/ZEN1/AVX512VNNI/AVXVNNI/AVX512/AVX2/SSE4.2/SSE4.1/SSSE3/SSE2/32bit環境用)
+              - 1.2.3.5.6.のトーナメントWindows版 (ZEN3/ZEN2/ZEN1/AVX512VNNI/AVXVNNI/AVX512/AVX2/SSE4.2)
+              - 1.2.3.の教師生成用実行ファイルWindows版 (ZEN3/ZEN2/ZEN1/AVX512VNNI/AVXVNNI/AVX512/AVX2/SSE4.2)
+              - 1.2.3.の学習用実行ファイルWindows版 (ZEN3/ZEN2/ZEN1/AVX512VNNI/AVXVNNI/AVX512/AVX2/SSE4.2)
             - [${{ steps.version.outputs.filename }}-material-windows.zip](https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/${{ steps.version.outputs.filename }}-material-windows.zip) (${{ steps.archive_size.outputs.material_windows_zip }})
             - [${{ steps.version.outputs.filename }}-material-windows.7z](https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/${{ steps.version.outputs.filename }}-material-windows.7z) (${{ steps.archive_size.outputs.material_windows_7z }})
-              - 4.の実行ファイルWindows版 各CPU向け(ZEN2/ZEN1/AVX2/SSE4.2/SSE2/32bit環境用)
-              - 4.のトーナメントWindows版 (ZEN2/ZEN1/AVX2/SSE4.2)
-              - 4.の教師生成用実行ファイルWindows版 (ZEN2/ZEN1/AVX2/SSE4.2)
+              - 4.の実行ファイルWindows版 各CPU向け(ZEN3/ZEN2/ZEN1/AVX2/SSE4.2/SSE2/32bit環境用)
+              - 4.のトーナメントWindows版 (ZEN3/ZEN2/ZEN1/AVX2/SSE4.2)
+              - 4.の教師生成用実行ファイルWindows版 (ZEN3/ZEN2/ZEN1/AVX2/SSE4.2)
             - [${{ steps.version.outputs.filename }}-deep-windows.zip](https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/${{ steps.version.outputs.filename }}-deep-windows.zip) (${{ steps.archive_size.outputs.deep_windows_zip }})
             - [${{ steps.version.outputs.filename }}-deep-windows.7z](https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/${{ steps.version.outputs.filename }}-deep-windows.7z) (${{ steps.archive_size.outputs.deep_windows_7z }})
               - 7.の実行ファイルWindows版 (AVX2)


### PR DESCRIPTION
https://twitter.com/msys2org/status/1451060685044129795
> Toolchain updates: clang/llvm 12.0.1 → 13.0.0 and gcc 10.3 → 11.2

msys2 toolchain の更新に伴い、 `ZEN3`, `AVXVNNI` を msys2 でのビルドテストおよびリリースビルドの対象に加えるよう変更します。
