### PR TITLE
- `false` デバッグログファイルの抑止

### DIFF
--- a/source/usi_option.cpp
+++ b/source/usi_option.cpp
@@ -129,7 +129,7 @@ namespace USI {
 #endif // !defined(TANUKI_MATE_ENGINE) && !defined(YANEURAOU_MATE_ENGINE)
 
 		// cin/coutの入出力をファイルにリダイレクトする
-		o["WriteDebugLog"] << Option(false, [](const Option& o) { start_logger(o); });
+		o["WriteDebugLog"] << Option("", [](const Option& o) { start_logger(o); });
 
 		// 読みの各局面ですべての合法手を生成する
 		// (普通、歩の2段目での不成などは指し手自体を生成しないが、


### PR DESCRIPTION
start_logger()の引数がboolから`std::string`に変更されたが、WriteDebugLogオプションのデフォルト値が`false`のままだったため、デフォルトではデバッグログがファイル名`false`に常に書き出されていた。
https://github.com/yaneurao/YaneuraOu/commit/fa10bc3ad096c265041fbfe82f7259bcfc5aa680#diff-56d0745227250f49421f61a56de172b8b68624734977a6ff2c8f4a5fd67d0ba2L120-R131