### PR TITLE
- リンク時最適化

### DIFF
--- a/.github/workflows/make-msys2.yml
+++ b/.github/workflows/make-msys2.yml
@@ -87,7 +87,7 @@ jobs:
           C:\msys64\usr\bin\bash.exe -lc 'pacman --needed --noconfirm -Syuu'
           C:\msys64\usr\bin\bash.exe -lc 'pacman --needed --noconfirm -Syuu'
           C:\msys64\usr\bin\bash.exe -lc 'pacman --needed --noconfirm -Syuu pactoys'
-          C:\msys64\usr\bin\bash.exe -lc 'pacboy --needed --noconfirm -Sy clang:m openblas:x openmp:x toolchain:m base-devel:'
+          C:\msys64\usr\bin\bash.exe -lc 'pacboy --needed --noconfirm -Sy clang:m lld:m openblas:x openmp:x toolchain:m base-devel:'
           $ErrorActionPreference = 'Stop'
 
       - name: make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           C:\msys64\usr\bin\bash.exe -lc 'pacman --needed --noconfirm -Syuu'
           C:\msys64\usr\bin\bash.exe -lc 'pacman --needed --noconfirm -Syuu'
           C:\msys64\usr\bin\bash.exe -lc 'pacman --needed --noconfirm -Syuu pactoys'
-          C:\msys64\usr\bin\bash.exe -lc 'pacboy --needed --noconfirm -Sy clang:m openblas:x openmp:x toolchain:m base-devel:'
+          C:\msys64\usr\bin\bash.exe -lc 'pacboy --needed --noconfirm -Sy clang:m lld:m openblas:x openmp:x toolchain:m base-devel:'
           $ErrorActionPreference = 'Stop'
 
       - name: make
@@ -188,7 +188,7 @@ jobs:
           C:\msys64\usr\bin\bash.exe -lc 'pacman --needed --noconfirm -Syuu'
           C:\msys64\usr\bin\bash.exe -lc 'pacman --needed --noconfirm -Syuu'
           C:\msys64\usr\bin\bash.exe -lc 'pacman --needed --noconfirm -Syuu pactoys'
-          C:\msys64\usr\bin\bash.exe -lc 'pacboy --needed --noconfirm -Sy clang:m openblas:x openmp:x toolchain:m base-devel:'
+          C:\msys64\usr\bin\bash.exe -lc 'pacboy --needed --noconfirm -Sy clang:m lld:m openblas:x openmp:x toolchain:m base-devel:'
           $ErrorActionPreference = 'Stop'
 
       - name: make
@@ -318,7 +318,7 @@ jobs:
           C:\msys64\usr\bin\bash.exe -lc 'pacman --needed --noconfirm -Syuu'
           C:\msys64\usr\bin\bash.exe -lc 'pacman --needed --noconfirm -Syuu'
           C:\msys64\usr\bin\bash.exe -lc 'pacman --needed --noconfirm -Syuu pactoys'
-          C:\msys64\usr\bin\bash.exe -lc 'pacboy --needed --noconfirm -Sy clang:m openblas:x openmp:x toolchain:m base-devel:'
+          C:\msys64\usr\bin\bash.exe -lc 'pacboy --needed --noconfirm -Sy clang:m lld:m openblas:x openmp:x toolchain:m base-devel:'
           $ErrorActionPreference = 'Stop'
 
       - name: suisho5 embedded_nnue

--- a/script/mingw_gcc.sh
+++ b/script/mingw_gcc.sh
@@ -21,8 +21,9 @@ COMPILERS="x86_64-w64-mingw32-g++-posix,i686-w64-mingw32-g++-posix"
 EDITIONS='*'
 OS='Windows_NT'
 TARGETS='*'
+EXTRA=''
 
-while getopts a:c:e:t: OPT
+while getopts a:c:e:t:x: OPT
 do
   case $OPT in
     a) ARCHCPUS="$OPTARG"
@@ -34,6 +35,8 @@ do
     o) OS="$OPTARG"
       ;;
     t) TARGETS="$OPTARG"
+      ;;
+    x) EXTRA="$OPTARG"
       ;;
   esac
 done
@@ -188,7 +191,7 @@ for COMPILER in ${COMPILERSARR[@]}; do
                     echo "* archcpu: ${ARCHCPU}"
                     TGSTR=${FILESTR[$EDITION]}-windows-${CSTR}-${TARGET}-${ARCHCPU}
                     ${MAKE} -f ${MAKEFILE} clean OS=${OS} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
-                    nice ${MAKE} -f ${MAKEFILE} -j${JOBS} ${TARGET} OS=${OS} TARGET_CPU=${ARCHCPU} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} COMPILER=${COMPILER} >& >(tee ${BUILDDIR}/${TGSTR}.log) || exit $?
+                    nice ${MAKE} -f ${MAKEFILE} -j${JOBS} ${TARGET} OS=${OS} TARGET_CPU=${ARCHCPU} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} COMPILER=${COMPILER} ${EXTRA} >& >(tee ${BUILDDIR}/${TGSTR}.log) || exit $?
                     cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TGSTR}.exe
                     ${MAKE} -f ${MAKEFILE} clean OS=${OS} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
                     break

--- a/script/msys2_build.ps1
+++ b/script/msys2_build.ps1
@@ -9,7 +9,7 @@
 # MSYS2をインストールしたディレクトリで（もしくはPATH環境変数を設定して）以下を実行:
 
 msys2_shell.cmd -msys2 -defterm -no-start -lc 'pacman --needed --noconfirm -Syuu pactoys';
-msys2_shell.cmd -msys2 -defterm -no-start -lc 'pacboy --needed --noconfirm -Syuu clang:m openblas:x openmp:x toolchain:m base-devel:';
+msys2_shell.cmd -msys2 -defterm -no-start -lc 'pacboy --needed --noconfirm -Syuu clang:m lld:m openblas:x openmp:x toolchain:m base-devel:';
 
 # MSYS2パッケージの更新、更新出来る項目が無くなるまで繰り返し実行、場合によってはMSYS2の再起動が必要
 #>

--- a/script/msys2_build.sh
+++ b/script/msys2_build.sh
@@ -21,20 +21,24 @@ MAKE=mingw32-make
 MAKEFILE=Makefile
 JOBS=`grep -c ^processor /proc/cpuinfo 2>/dev/null`
 
+ARCHCPUS='*'
 COMPILERS="clang++,g++"
 EDITIONS='*'
 TARGETS='*'
+EXTRA=''
 
-while getopts c:e:t:p: OPT
+while getopts a:c:e:t:x: OPT
 do
   case $OPT in
+    a) ARCHCPUS="$OPTARG"
+      ;;
     c) COMPILERS="$OPTARG"
       ;;
     e) EDITIONS="$OPTARG"
       ;;
     t) TARGETS="$OPTARG"
       ;;
-    p) CPUS="$OPTARG"
+    x) EXTRA="$OPTARG"
       ;;
   esac
 done
@@ -42,7 +46,7 @@ done
 set -f
 IFS=, eval 'COMPILERSARR=($COMPILERS)'
 IFS=, eval 'EDITIONSARR=($EDITIONS)'
-IFS=, eval 'CPUSARR=($CPUS)'
+IFS=, eval 'ARCHCPUSARR=($ARCHCPUS)'
 IFS=, eval 'TARGETSARR=($TARGETS)'
 
 pushd `dirname $0`
@@ -77,7 +81,7 @@ TARGETS=(
   gensfen
 )
 
-CPUS=(
+ARCHCPUS=(
   ZEN3
   ZEN2
   ZEN1
@@ -180,14 +184,14 @@ for COMPILER in ${COMPILERSARR[@]}; do
             if [[ $TARGET == $TARGETPTN ]]; then
               set -f
               echo "* target: ${TARGET}"
-              for CPU in ${CPUS[@]}; do
-                for CPUPTN in ${CPUSARR[@]}; do
+              for ARCHCPU in ${ARCHCPUS[@]}; do
+                for ARCHCPUSPTN in ${ARCHCPUSARR[@]}; do
                   set +f
-                  if [[ $CPU == $CPUPTN ]]; then
+                  if [[ $ARCHCPU == $ARCHCPUSPTN ]]; then
                     echo "* cpu: ${CPU}"
                     TGSTR=${FILESTR[$EDITION]}-msys2-${CSTR}-${TARGET}
                     ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
-                    nice ${MAKE} -f ${MAKEFILE} -j${JOBS} ${TARGET} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} COMPILER=${COMPILER} TARGET_CPU=${CPU} >& >(tee ${BUILDDIR}/${TGSTR}.log) || exit $?
+                    nice ${MAKE} -f ${MAKEFILE} -j${JOBS} ${TARGET} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} COMPILER=${COMPILER} TARGET_CPU=${ARCHCPU} ${EXTRA} >& >(tee ${BUILDDIR}/${TGSTR}.log) || exit $?
                     cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TGSTR}.exe
                     ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
                     set -f

--- a/script/msys2_build.sh
+++ b/script/msys2_build.sh
@@ -3,7 +3,7 @@
 # MSYS2 (MinGW 64-bit) 上で Windows バイナリのビルド
 # ビルド用パッケージの導入
 # $ pacman --needed --noconfirm -Syuu pactoys
-# $ pacboy --needed --noconfirm -Syuu clang:m openblas:x openmp:x toolchain:m base-devel:
+# $ pacboy --needed --noconfirm -Syuu clang:m lld:m openblas:x openmp:x toolchain:m base-devel:
 # MSYS2パッケージの更新、更新出来る項目が無くなるまで繰り返し実行、場合によってはMSYS2の再起動が必要
 # $ pacman -Syuu --noconfirm
 

--- a/script/msys2_build32.sh
+++ b/script/msys2_build32.sh
@@ -3,7 +3,7 @@
 # MSYS2 (MinGW 32-bit) 上で Windows バイナリのビルド
 # ビルド用パッケージの導入
 # $ pacman --needed --noconfirm -Syuu pactoys
-# $ pacboy --needed --noconfirm -Syuu clang:m openblas:x openmp:x toolchain:m base-devel:
+# $ pacboy --needed --noconfirm -Syuu clang:m lld:m openblas:x openmp:x toolchain:m base-devel:
 # MSYS2パッケージの更新、更新出来る項目が無くなるまで繰り返し実行、場合によってはMSYS2の再起動が必要
 # $ pacman -Syuu --noconfirm
 

--- a/script/msys2_build32.sh
+++ b/script/msys2_build32.sh
@@ -24,8 +24,9 @@ JOBS=`grep -c ^processor /proc/cpuinfo 2>/dev/null`
 COMPILERS="clang++,g++"
 EDITIONS='*'
 TARGETS='*'
+EXTRA=''
 
-while getopts c:e:t: OPT
+while getopts c:e:t:x: OPT
 do
   case $OPT in
     c) COMPILERS="$OPTARG"
@@ -33,6 +34,8 @@ do
     e) EDITIONS="$OPTARG"
       ;;
     t) TARGETS="$OPTARG"
+      ;;
+    x) EXTRA="$OPTARG"
       ;;
   esac
 done
@@ -163,7 +166,7 @@ for COMPILER in ${COMPILERSARR[@]}; do
               echo "* target: ${TARGET}"
               TGSTR=YaneuraOu-${FILESTR[$EDITION]}-msys2-${CSTR}-${TARGET}
               ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
-              nice ${MAKE} -f ${MAKEFILE} -j${JOBS} ${TARGET} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} COMPILER=${COMPILER} TARGET_CPU=NO_SSE >& >(tee ${BUILDDIR}/${TGSTR}.log) || exit $?
+              nice ${MAKE} -f ${MAKEFILE} -j${JOBS} ${TARGET} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} COMPILER=${COMPILER} TARGET_CPU=NO_SSE ${EXTRA} >& >(tee ${BUILDDIR}/${TGSTR}.log) || exit $?
               cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TGSTR}.exe
               ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
               set -f

--- a/source/Makefile
+++ b/source/Makefile
@@ -131,7 +131,7 @@ endif
 # clang用にCPPFLAGSなどを変更
 ifneq (,$(findstring clang++,$(COMPILER)))
 	# stdlib
-	CPPFLAGS += -stdlib=libstdc++
+	# CPPFLAGS += -stdlib=libstdc++
 
 	# C++17のfilesystem
 	# LDFLAGS += -lstdc++fs

--- a/source/Makefile
+++ b/source/Makefile
@@ -175,6 +175,13 @@ endif
 # cf. https://gcc.gnu.org/onlinedocs/gcc-6.3.0/gcc/Optimize-Options.html#Optimize-Options
 LTOFLAGS = -flto
 
+# MSYS2 clang++ で -flto 指定時にリンクを行えない問題の回避
+ifneq (,$(findstring clang++,$(COMPILER)))
+	ifeq ($(OS),Windows_NT)
+		LDFLAGS += -fuse-ld=lld
+	endif
+endif
+
 # wstringを使うためにこのシンボル定義が必要。
 CPPFLAGS  += -DUNICODE
 
@@ -533,19 +540,19 @@ $(OBJDIR)/%.o: %.cpp
 
 # 通常使用。
 normal:
-	$(MAKE) CPPFLAGS='$(CPPFLAGS)' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
+	$(MAKE) CPPFLAGS='$(CPPFLAGS) $(LTOFLAGS)' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
 
 # 学習用。openmp , openblasなどを有効にする。
 evallearn:
-	$(MAKE) CPPFLAGS='$(CPPFLAGS) $(OPENMP) $(BLAS_CPPFLAGS) -DEVAL_LEARN' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
+	$(MAKE) CPPFLAGS='$(CPPFLAGS) $(LTOFLAGS) $(OPENMP) $(BLAS_CPPFLAGS) -DEVAL_LEARN' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
 
 # トーナメント用
 tournament:
-	$(MAKE) CPPFLAGS='$(CPPFLAGS) -DFOR_TOURNAMENT' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
+	$(MAKE) CPPFLAGS='$(CPPFLAGS) $(LTOFLAGS) -DFOR_TOURNAMENT' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
 
 # 教師棋譜生成用(開発用なので非公開) // currently private
 gensfen:
-	$(MAKE) CPPFLAGS='$(CPPFLAGS) $(OPENMP) $(BLAS_CPPFLAGS) -DEVAL_LEARN -DGENSFEN2019' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
+	$(MAKE) CPPFLAGS='$(CPPFLAGS) $(LTOFLAGS) $(OPENMP) $(BLAS_CPPFLAGS) -DEVAL_LEARN -DGENSFEN2019' LDFLAGS='$(LDFLAGS) $(OPENMP_LDFLAGS) $(BLAS_LDFLAGS) $(LTOFLAGS)' $(TARGET)
 
 
 #　とりあえずPGOはAVX2とSSE4.2専用
@@ -556,7 +563,7 @@ profgen:
 	$(MAKE) CPPFLAGS='$(CPPFLAGS) -fprofile-generate -lgcov' LDFLAGS='$(LDFLAGS) -fprofile-generate -lgcov'
 
 profuse:
-	$(MAKE) CPPFLAGS='$(CPPFLAGS) -fprofile-use -lgcov' LDFLAGS='$(LDFLAGS) -fprofile-use -lgcov $(LTOFLAGS)'
+	$(MAKE) CPPFLAGS='$(CPPFLAGS) $(LTOFLAGS) -fprofile-use -lgcov' LDFLAGS='$(LDFLAGS) -fprofile-use -lgcov $(LTOFLAGS)'
 
 pgo:
 	$(MAKE) profgen


### PR DESCRIPTION
```
python.exe .\script\bench.py --cmd "32768 16 30 default time" --loop 10 D:\shogi\engine\Suisho5-YaneuraOu-v7.0.0-beta3-windows\YaneuraOu_NNUE-tournament-clang++-zen2.exe "<internal>" D:\shogi\engine\Suisho5-YaneuraOu-v7.0.0-beta3+20211206c.lto-windows\YaneuraOu_NNUE-tournament-clang++-zen2.exe "<internal>"
```

```
2021-12-06 21:13:28,602 OS: Windows
2021-12-06 21:13:28,604
cmd: 32768 16 30 default time
engine1: D:\shogi\engine\Suisho5-YaneuraOu-v7.0.0-beta3-windows\YaneuraOu_NNUE-tournament-clang++-zen2.exe
engine2: D:\shogi\engine\Suisho5-YaneuraOu-v7.0.0-beta3+20211206c.lto-windows\YaneuraOu_NNUE-tournament-clang++-zen2.exe
eval1: <internal>
eval2: <internal>
log: bench.log
loop: 10

run       base       test     diff
  1   14657895   14921992  +264097
  2   14647533   14812395  +164862
  3   14647304   14953527  +306223
  4   14718774   15258585  +539811
  5   15039213   15047941    +8728
  6   14651618   15220419  +568801
  7   15039541   15074553   +35012
  8   14694375   14990882  +296507
  9   14766935   14865375   +98440
 10   14502991   15081190  +578199
2021-12-06 21:54:29,692 

   time_e1    nodes_e1    nps_e1  time_e2    nodes_e2    nps_e2  nps_diff
0   120003  1758991489  14657895   120003  1790683827  14921992    264097
1   120002  1757733275  14647533   120006  1777576361  14812395    164862
2   120003  1757720486  14647304   120004  1794483166  14953527    306223
3   120001  1766267649  14718774   120005  1831106507  15258585    539811
4   120004  1804765774  15039213   120004  1805813125  15047941      8728
5   120004  1758252866  14651618   120003  1826496038  15220419    568801
6   120003  1804790074  15039541   120002  1808976611  15074553     35012
7   120003  1763369158  14694375   120003  1798950876  14990882    296507
8   120002  1772061842  14766935   120005  1783919395  14865375     98440
9   120003  1740402488  14502991   120002  1809772984  15081190    578199

          time_e1    nodes_e1      nps_e1     time_e2    nodes_e2      nps_e2    nps_diff
count          10          10          10          10          10          10          10
mean       120003  1768435510    14736618      120004  1802777889    15022686      286068
std             1    20798333      173290           1    17263011      143914      216154
min        120001  1740402488    14502991      120002  1777576361    14812395        8728
25%        120002  1757863173    14648554      120003  1791633662    14929876      115046
50%        120003  1761180324    14676135      120004  1802382000    15019412      280302
75%        120003  1770613294    14754895      120005  1809573891    15079531      481414
max        120004  1804790074    15039541      120006  1831106507    15258585      578199

Result of 10 runs
==================
base           =   14736618 +/- 173290
test           =   15022686 +/- 143914
diff           =    +286068 +/- 216154

speedup        = +0.0194
P(speedup > 0) = 0.9996

Vendor ID         : AuthenticAMD
CPU Name          : AMD Ryzen Threadripper 3970X 32-Core Processor
Microarchitecture : x86_64
```