### PR TITLE
- make clean $extra

### DIFF
--- a/script/android_build.ps1
+++ b/script/android_build.ps1
@@ -106,7 +106,7 @@ if(-not (Test-Path $Dir)){
 }
 
 "`n* Clean Build"|Out-Host;
-ndk-build.cmd clean YANEURAOU_EDITION=$_Edition;
+ndk-build.cmd clean YANEURAOU_EDITION=$_Edition $Extra;
 
 "`n* Build Binary"|Out-Host;
 $log = $null;
@@ -120,7 +120,7 @@ ForEach-Object{
 };
 
 "`n* Clean Build"|Out-Host;
-ndk-build.cmd clean YANEURAOU_EDITION=$_Edition;
+ndk-build.cmd clean YANEURAOU_EDITION=$_Edition $Extra;
 
 }
 

--- a/script/android_build.sh
+++ b/script/android_build.sh
@@ -99,10 +99,10 @@ for EDITION in ${EDITIONS[@]}; do
       echo "* edition: ${EDITION}"
       BUILDDIR=build/android/${DIRSTR[$EDITION]}
       mkdir -p ${BUILDDIR}
-      ndk-build clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
+      ndk-build clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} ${EXTRA}
       ndk-build -j${JOBS} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} V=1 ${EXTRA} >& >(tee ${BUILDDIR}/build.log) || exit $?
       bash -c "cp libs/**/* ${BUILDDIR}"
-      ndk-build clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
+      ndk-build clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} ${EXTRA}
       break
     fi
     set -f

--- a/script/build.sh
+++ b/script/build.sh
@@ -195,9 +195,9 @@ for COMPILER in ${COMPILERSARR[@]}; do
                     set -f
                     echo "* archcpu: ${ARCHCPU}"
                     TGSTR=${FILESTR[$EDITION]}-${OS}-${CSTR}-${TARGET}-${ARCHCPU}
-                    ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
+                    ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} ${EXTRA}
                     nice ${MAKE} -f ${MAKEFILE} -j${JOBS} ${TARGET} TARGET_CPU=${ARCHCPU} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} COMPILER=${COMPILER} TARGET=${BUILDDIR}/${TGSTR} ${EXTRA} >& >(tee ${BUILDDIR}/${TGSTR}.log) || exit $?
-                    ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
+                    ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} ${EXTRA}
                     break
                   fi
                   set -f

--- a/script/mingw_gcc.sh
+++ b/script/mingw_gcc.sh
@@ -190,10 +190,10 @@ for COMPILER in ${COMPILERSARR[@]}; do
                     set -f
                     echo "* archcpu: ${ARCHCPU}"
                     TGSTR=${FILESTR[$EDITION]}-windows-${CSTR}-${TARGET}-${ARCHCPU}
-                    ${MAKE} -f ${MAKEFILE} clean OS=${OS} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
+                    ${MAKE} -f ${MAKEFILE} clean OS=${OS} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} ${EXTRA}
                     nice ${MAKE} -f ${MAKEFILE} -j${JOBS} ${TARGET} OS=${OS} TARGET_CPU=${ARCHCPU} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} COMPILER=${COMPILER} ${EXTRA} >& >(tee ${BUILDDIR}/${TGSTR}.log) || exit $?
                     cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TGSTR}.exe
-                    ${MAKE} -f ${MAKEFILE} clean OS=${OS} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
+                    ${MAKE} -f ${MAKEFILE} clean OS=${OS} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} ${EXTRA}
                     break
                   fi
                   set -f

--- a/script/msys2_build.ps1
+++ b/script/msys2_build.ps1
@@ -179,7 +179,7 @@ function MakeExec($o) {
   msys2_shell.cmd -here -defterm -no-start $MinGW -lc "nice $($o.Make) -f $($o.Makefile) -j$($o.Jobs) $($o.Target) YANEURAOU_EDITION=$($o.Edition) COMPILER=$($o.Compiler) OS=$($o.Os) TARGET_CPU=$($o.Cpu) OBJDIR=$TempDirCyg TARGETDIR=$TempDirCyg $($o.Extra) 2>&1"|Tee-Object -Variable log;
   $log|Out-File -Encoding utf8 -Force (Join-Path $o.BuildDir "$($o.BuildName)-$($o.Target)-$($o.Compiler)-$($o.Cpu.ToLower()).log");
   Copy-Item (Join-Path $TempDir YaneuraOu-by-gcc.exe) (Join-Path $o.BuildDir "$($o.BuildName)-$($o.Target)-$($o.Compiler)-$($o.Cpu.ToLower()).exe") -Force;
-  msys2_shell.cmd -here -defterm -no-start $MinGW -lc "$($o.Make) -f $($o.Makefile) clean YANEURAOU_EDITION=$($o.Edition) OBJDIR=$TempDirCyg TARGETDIR=$TempDirCyg";
+  msys2_shell.cmd -here -defterm -no-start $MinGW -lc "$($o.Make) -f $($o.Makefile) $($o.Extra) clean YANEURAOU_EDITION=$($o.Edition) OBJDIR=$TempDirCyg TARGETDIR=$TempDirCyg";
   $TempDir|Where-Object{ Test-Path $_ }|Remove-Item -Recurse;
   Pop-Location;
 }

--- a/script/msys2_build.sh
+++ b/script/msys2_build.sh
@@ -190,10 +190,10 @@ for COMPILER in ${COMPILERSARR[@]}; do
                   if [[ $ARCHCPU == $ARCHCPUSPTN ]]; then
                     echo "* cpu: ${CPU}"
                     TGSTR=${FILESTR[$EDITION]}-msys2-${CSTR}-${TARGET}
-                    ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
+                    ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} ${EXTRA}
                     nice ${MAKE} -f ${MAKEFILE} -j${JOBS} ${TARGET} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} COMPILER=${COMPILER} TARGET_CPU=${ARCHCPU} ${EXTRA} >& >(tee ${BUILDDIR}/${TGSTR}.log) || exit $?
                     cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TGSTR}.exe
-                    ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
+                    ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} ${EXTRA}
                     set -f
                     break
                   fi

--- a/script/msys2_build32.sh
+++ b/script/msys2_build32.sh
@@ -165,10 +165,10 @@ for COMPILER in ${COMPILERSARR[@]}; do
             if [[ $TARGET == $TARGETPTN ]]; then
               echo "* target: ${TARGET}"
               TGSTR=YaneuraOu-${FILESTR[$EDITION]}-msys2-${CSTR}-${TARGET}
-              ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
+              ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} ${EXTRA}
               nice ${MAKE} -f ${MAKEFILE} -j${JOBS} ${TARGET} YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} COMPILER=${COMPILER} TARGET_CPU=NO_SSE ${EXTRA} >& >(tee ${BUILDDIR}/${TGSTR}.log) || exit $?
               cp YaneuraOu-by-gcc.exe ${BUILDDIR}/${TGSTR}.exe
-              ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]}
+              ${MAKE} -f ${MAKEFILE} clean YANEURAOU_EDITION=${EDITIONSTR[$EDITION]} ${EXTRA}
               set -f
               break
             fi


### PR DESCRIPTION
`EVAL_EMBEDDING=ON` のような、ソースファイルの構成が変化する追加オプションを指定した場合、ビルド用スクリプトファイルから `make clean` を呼び出す時にその指定が欠けていたため、前のビルドで使われたオブジェクトファイルが掃除し切れていないケースがありました。（自動ビルド以外のケースにおいて）

例えば、`EVAL_EMBEDDING=ON` 付きでコンパイラ `g++` , `clang++` の両方でビルドする際、前のビルドで作られた `embedded_nnue.o` が残っていたためにリンカエラーを起こす事がありました。（ソースファイルのコンパイル時、オブジェクトファイルに付与されるLTOのヒント情報が `g++`, `clang++` の間で互換性がないため。）