### PR TITLE
- sln: vs2022

### DIFF
--- a/YaneuraOu.sln
+++ b/YaneuraOu.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.156
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32421.90
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "YaneuraOu", "source\YaneuraOu.vcxproj", "{28C8605A-4E8E-4F59-99B5-96F545BC7D5E}"
 EndProject
@@ -120,8 +120,8 @@ Global
 		{28C8605A-4E8E-4F59-99B5-96F545BC7D5E}.Release-Material|x86.ActiveCfg = Release-Material|x64
 		{28C8605A-4E8E-4F59-99B5-96F545BC7D5E}.Release-NNUE|x64.ActiveCfg = Release-NNUE|x64
 		{28C8605A-4E8E-4F59-99B5-96F545BC7D5E}.Release-NNUE|x64.Build.0 = Release-NNUE|x64
-		{28C8605A-4E8E-4F59-99B5-96F545BC7D5E}.Release-NNUE|x86.ActiveCfg = Release-NNUE-SSE42|x64
-		{28C8605A-4E8E-4F59-99B5-96F545BC7D5E}.Release-NNUE|x86.Build.0 = Release-NNUE-SSE42|x64
+		{28C8605A-4E8E-4F59-99B5-96F545BC7D5E}.Release-NNUE|x86.ActiveCfg = Release-NNUE|x64
+		{28C8605A-4E8E-4F59-99B5-96F545BC7D5E}.Release-NNUE|x86.Build.0 = Release-NNUE|x64
 		{28C8605A-4E8E-4F59-99B5-96F545BC7D5E}.Release-NNUE-LEARN|x64.ActiveCfg = Release-NNUE-LEARN|x64
 		{28C8605A-4E8E-4F59-99B5-96F545BC7D5E}.Release-NNUE-LEARN|x64.Build.0 = Release-NNUE-LEARN|x64
 		{28C8605A-4E8E-4F59-99B5-96F545BC7D5E}.Release-NNUE-LEARN|x86.ActiveCfg = Release-NNUE-LEARN|x64


### PR DESCRIPTION
@nodchip さんの指摘より作成。

> PC に複数バージョンの VS がインストールされている環境で、 .sln に Visual Studio Selector を関連付けている場合、古いバージョンの VS で開かれるという問題がありそうです。

> VS2022 で .sln ファイルを開いたあと、開いている最中に .sln ファイルを削除し、 VS2022 の GUI 上ですべて保存をすると、 .sln ファイルがアップグレードされた状態で復活すると思います。

ついでですが、未使用と思われるターゲット(x86)の対応に誤りがあったので修正。