### PR TITLE
Deal with `-Wbitwise-op-parentheses`

### DIFF
--- a/source/bitboard.h
+++ b/source/bitboard.h
@@ -962,7 +962,7 @@ inline Bitboard rookFileEffect(Square sq, const Bitboard& occupied)
 		mocc >>= 1;
 
 		// 後手の香の利きと先手の香の利きを合成
-		return Bitboard((em ^ t) & mask | (~mocc & se), 0);
+		return Bitboard(((em ^ t) & mask) | (~mocc & se), 0);
 	}
 	else {
 		// 飛車がp[1]に属する
@@ -979,7 +979,7 @@ inline Bitboard rookFileEffect(Square sq, const Bitboard& occupied)
 		mocc |= mocc >> 4;
 		mocc >>= 1;
 
-		return Bitboard(0, (em ^ t) & mask | (~mocc & se));
+		return Bitboard(0, ((em ^ t) & mask) | (~mocc & se));
 	}
 }
 


### PR DESCRIPTION
clang++ でコンパイルすると以下のような警告が出力されます:
```
engine/yaneuraou-engine/../../bitboard.h:965:28: warning: '&' within '|' [-Wbitwise-op-parentheses]
                return Bitboard((em ^ t) & mask | (~mocc & se), 0);
                                ~~~~~~~~~^~~~~~ ~
engine/yaneuraou-engine/../../bitboard.h:965:28: note: place parentheses around the '&' expression to silence this warning
                return Bitboard((em ^ t) & mask | (~mocc & se), 0);
                                         ^
                                (              )
engine/yaneuraou-engine/../../bitboard.h:982:31: warning: '&' within '|' [-Wbitwise-op-parentheses]
                return Bitboard(0, (em ^ t) & mask | (~mocc & se));
                                   ~~~~~~~~~^~~~~~ ~
engine/yaneuraou-engine/../../bitboard.h:982:31: note: place parentheses around the '&' expression to silence this warning
                return Bitboard(0, (em ^ t) & mask | (~mocc & se));
                                            ^
                                   (              )
```
この PR ではそれに対処します。