### PR TITLE
Fix overflow in add_dpbusd_epi32x2

### DIFF
--- a/source/eval/nnue/layers/affine_transform.h
+++ b/source/eval/nnue/layers/affine_transform.h
@@ -212,9 +212,9 @@ class AffineTransform {
 #else
 			__m512i product0 = _mm512_maddubs_epi16(a0, b0);
 			__m512i product1 = _mm512_maddubs_epi16(a1, b1);
-			product0         = _mm512_adds_epi16(product0, product1);
-			product0         = _mm512_madd_epi16(product0, kOnes512);
-			acc              = _mm512_add_epi32(acc, product0);
+			product0 = _mm512_madd_epi16(product0, _mm512_set1_epi16(1));
+			product1 = _mm512_madd_epi16(product1, _mm512_set1_epi16(1));
+			acc = _mm512_add_epi32(acc, _mm512_add_epi32(product0, product1));
 #endif
 		};
 
@@ -261,9 +261,9 @@ class AffineTransform {
 #else
 			__m256i product0 = _mm256_maddubs_epi16(a0, b0);
 			__m256i product1 = _mm256_maddubs_epi16(a1, b1);
-			product0         = _mm256_adds_epi16(product0, product1);
-			product0         = _mm256_madd_epi16(product0, kOnes256);
-			acc              = _mm256_add_epi32(acc, product0);
+			product0 = _mm256_madd_epi16(product0, _mm256_set1_epi16(1));
+			product1 = _mm256_madd_epi16(product1, _mm256_set1_epi16(1));
+			acc = _mm256_add_epi32(acc, _mm256_add_epi32(product0, product1));
 #endif
 		};
 
@@ -299,9 +299,9 @@ class AffineTransform {
 		                                                    __m128i b1) {
 			__m128i product0 = _mm_maddubs_epi16(a0, b0);
 			__m128i product1 = _mm_maddubs_epi16(a1, b1);
-			product0         = _mm_adds_epi16(product0, product1);
-			product0         = _mm_madd_epi16(product0, kOnes128);
-			acc              = _mm_add_epi32(acc, product0);
+			product0 = _mm_madd_epi16(product0, _mm_set1_epi16(1));
+			product1 = _mm_madd_epi16(product1, _mm_set1_epi16(1));
+			acc = _mm_add_epi32(acc, _mm_add_epi32(product0, product1));
 		};
 
 #endif

--- a/source/eval/nnue/nnue_feature_transformer.h
+++ b/source/eval/nnue/nnue_feature_transformer.h
@@ -24,7 +24,7 @@ namespace Eval::NNUE {
 #define VECTOR
 
 #if defined(USE_AVX512)
-typedef __m512i vec_t;
+using vec_t = __m512i;
 #define vec_load(a) _mm512_load_si512(a)
 #define vec_store(a, b) _mm512_store_si512(a, b)
 #define vec_add_16(a, b) _mm512_add_epi16(a, b)
@@ -33,7 +33,7 @@ typedef __m512i vec_t;
 static constexpr IndexType kNumRegs = 8;  // only 8 are needed
 
 #elif defined(USE_AVX2)
-typedef __m256i vec_t;
+using vec_t = __m256i;
 #define vec_load(a) _mm256_load_si256(a)
 #define vec_store(a, b) _mm256_store_si256(a, b)
 #define vec_add_16(a, b) _mm256_add_epi16(a, b)
@@ -42,7 +42,7 @@ typedef __m256i vec_t;
 static constexpr IndexType kNumRegs = 16;
 
 #elif defined(USE_SSE2)
-typedef __m128i vec_t;
+using vec_t = __m128i;
 #define vec_load(a) (*(a))
 #define vec_store(a, b) *(a) = (b)
 #define vec_add_16(a, b) _mm_add_epi16(a, b)
@@ -51,7 +51,7 @@ typedef __m128i vec_t;
 static constexpr IndexType kNumRegs = Is64Bit ? 16 : 8;
 
 #elif defined(USE_MMX)
-typedef __m64 vec_t;
+using vec_t = __m64;
 #define vec_load(a) (*(a))
 #define vec_store(a, b) *(a) = (b)
 #define vec_add_16(a, b) _mm_add_pi16(a, b)
@@ -60,7 +60,7 @@ typedef __m64 vec_t;
 static constexpr IndexType kNumRegs = 8;
 
 #elif defined(USE_NEON)
-typedef int16x8_t vec_t;
+using vec_t = int16x8_t;
 #define vec_load(a) (*(a))
 #define vec_store(a, b) *(a) = (b)
 #define vec_add_16(a, b) vaddq_s16(a, b)


### PR DESCRIPTION
Stockfish の

- https://github.com/official-stockfish/Stockfish/commit/564456a6a824bfca26d6d9af5b35a055eb9fc6c2
- https://github.com/official-stockfish/Stockfish/commit/2c36d1e7e7374b8babb3cc503c0bc07ceb83dbf8

 をマージするためのプルリクエストです。 nps は変更前と変更後で以下のように変化しています。

変更前

```
===========================
Total time (ms) : 60004
Nodes searched  : 77916762
Nodes_searched/second    : 1298526
===========================

===========================
Total time (ms) : 60029
Nodes searched  : 78165853
Nodes_searched/second    : 1302134
===========================

===========================
Total time (ms) : 60006
Nodes searched  : 78021690
Nodes_searched/second    : 1300231
===========================

```
変更後

```
===========================
Total time (ms) : 60008
Nodes searched  : 77163881
Nodes_searched/second    : 1285893
===========================

===========================
Total time (ms) : 60004
Nodes searched  : 78026514
Nodes_searched/second    : 1300355
===========================

===========================
Total time (ms) : 60005
Nodes searched  : 77763262
Nodes_searched/second    : 1295946
===========================
```

計測は、 標準 NNUE (halfkp_256x2-32-32) 評価関数『Háo』を用いて行いました。

よろしくお願いいたします。