### PR TITLE
file_ofでテーブルを使わず、直接計算するように変更した

### DIFF
--- a/source/types.h
+++ b/source/types.h
@@ -175,43 +175,11 @@ constexpr bool is_ok(Square sq) { return SQ_ZERO <= sq && sq <= SQ_NB; }
 // sqが盤面の内側を指しているかを判定する。assert()などで使う用。玉は盤上にないときにSQ_NBを取るのでこの関数が必要。
 constexpr bool is_ok_plus1(Square sq) { return SQ_ZERO <= sq && sq < SQ_NB_PLUS1; }
 
-// 与えられたSquareに対応する筋を返すテーブル。file_of()で用いる。
-constexpr File SquareToFile[SQ_NB_PLUS1] =
-{
-	FILE_1, FILE_1, FILE_1, FILE_1, FILE_1, FILE_1, FILE_1, FILE_1, FILE_1,
-	FILE_2, FILE_2, FILE_2, FILE_2, FILE_2, FILE_2, FILE_2, FILE_2, FILE_2,
-	FILE_3, FILE_3, FILE_3, FILE_3, FILE_3, FILE_3, FILE_3, FILE_3, FILE_3,
-	FILE_4, FILE_4, FILE_4, FILE_4, FILE_4, FILE_4, FILE_4, FILE_4, FILE_4,
-	FILE_5, FILE_5, FILE_5, FILE_5, FILE_5, FILE_5, FILE_5, FILE_5, FILE_5,
-	FILE_6, FILE_6, FILE_6, FILE_6, FILE_6, FILE_6, FILE_6, FILE_6, FILE_6,
-	FILE_7, FILE_7, FILE_7, FILE_7, FILE_7, FILE_7, FILE_7, FILE_7, FILE_7,
-	FILE_8, FILE_8, FILE_8, FILE_8, FILE_8, FILE_8, FILE_8, FILE_8, FILE_8,
-	FILE_9, FILE_9, FILE_9, FILE_9, FILE_9, FILE_9, FILE_9, FILE_9, FILE_9,
-	FILE_NB, // 玉が盤上にないときにこの位置に移動させることがあるので
-};
-
 // 与えられたSquareに対応する筋を返す。
-// →　行数は長くなるが速度面においてテーブルを用いる。
-constexpr File file_of(Square sq) { /* return (File)(sq / 9); */ /*ASSERT_LV2(is_ok(sq));*/ return SquareToFile[sq]; }
-
-// 与えられたSquareに対応する段を返すテーブル。rank_of()で用いる。
-constexpr Rank SquareToRank[SQ_NB_PLUS1] =
-{
-	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
-	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
-	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
-	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
-	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
-	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
-	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
-	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
-	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
-	RANK_NB, // 玉が盤上にないときにこの位置に移動させることがあるので
-};
+constexpr File file_of(Square sq) { return (File)(sq / 9); }
 
 // 与えられたSquareに対応する段を返す。
-// →　行数は長くなるが速度面においてテーブルを用いる。
-constexpr Rank rank_of(Square sq) { /* return (Rank)(sq % 9); */ /*ASSERT_LV2(is_ok(sq));*/ return SquareToRank[sq]; }
+constexpr Rank rank_of(Square sq) { return (Rank)(sq % 9); }
 
 // 筋(File)と段(Rank)から、それに対応する升(Square)を返す。
 constexpr Square operator | (File f, Rank r) { Square sq = (Square)(f * 9 + r); /* ASSERT_LV2(is_ok(sq));*/ return sq; }

--- a/source/types.h
+++ b/source/types.h
@@ -176,10 +176,10 @@ constexpr bool is_ok(Square sq) { return SQ_ZERO <= sq && sq <= SQ_NB; }
 constexpr bool is_ok_plus1(Square sq) { return SQ_ZERO <= sq && sq < SQ_NB_PLUS1; }
 
 // 与えられたSquareに対応する筋を返す。
-constexpr File file_of(Square sq) { return (File)(sq / 9); }
+constexpr File file_of(Square sq) { return (File)(sq * 115 >> 10); }
 
 // 与えられたSquareに対応する段を返す。
-constexpr Rank rank_of(Square sq) { return (Rank)(sq % 9); }
+constexpr Rank rank_of(Square sq) { return (Rank)(sq - (sq * 115 >> 10) * 9); }
 
 // 筋(File)と段(Rank)から、それに対応する升(Square)を返す。
 constexpr Square operator | (File f, Rank r) { Square sq = (Square)(f * 9 + r); /* ASSERT_LV2(is_ok(sq));*/ return sq; }

--- a/source/types.h
+++ b/source/types.h
@@ -178,8 +178,24 @@ constexpr bool is_ok_plus1(Square sq) { return SQ_ZERO <= sq && sq < SQ_NB_PLUS1
 // 与えられたSquareに対応する筋を返す。
 constexpr File file_of(Square sq) { return (File)(sq * 115 >> 10); }
 
+// 与えられたSquareに対応する段を返すテーブル。rank_of()で用いる。
+constexpr Rank SquareToRank[SQ_NB_PLUS1] =
+{
+	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
+	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
+	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
+	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
+	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
+	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
+	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
+	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
+	RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_9,
+	RANK_NB, // 玉が盤上にないときにこの位置に移動させることがあるので
+};
+
 // 与えられたSquareに対応する段を返す。
-constexpr Rank rank_of(Square sq) { return (Rank)(sq - (sq * 115 >> 10) * 9); }
+// →　行数は長くなるが速度面においてテーブルを用いる。
+constexpr Rank rank_of(Square sq) { /* return (Rank)(sq % 9); */ /*ASSERT_LV2(is_ok(sq));*/ return SquareToRank[sq]; }
 
 // 筋(File)と段(Rank)から、それに対応する升(Square)を返す。
 constexpr Square operator | (File f, Rank r) { Square sq = (Square)(f * 9 + r); /* ASSERT_LV2(is_ok(sq));*/ return sq; }


### PR DESCRIPTION
# 改善点
file_ofでテーブルを使っていたところを乗算とシフトを使ったコードに変更したところ、Windows 11 + Zen 4 + clang 18では約3%の速度の向上が確認されました。ただし、これらの変更が他の環境でも同様の改善をもたらすかは確認できていないため、他の環境でもテストすることを推奨します。
なお、rank_ofはおそらくテーブルを使う方が早そうです。

## 変更点
以下のコードに変更しました。
```cpp
// 与えられたSquareに対応する筋を返す。
constexpr File file_of(Square sq) { return (File)(sq * 115 >> 10); }
```

# ベンチマーク

Windows 11 + R9-7945HX + RAM 32GBでのベンチマークの結果は以下の通りです。

## 変更前
```bash
Run  1: 28417182 nps
Run  2: 27780337 nps
Run  3: 28288643 nps
Run  4: 27709807 nps
Run  5: 27816678 nps
Run  6: 28180029 nps
Run  7: 28081823 nps
Run  8: 27698790 nps
Run  9: 28429205 nps
Run 10: 27552542 nps
Run 11: 27769954 nps
Run 12: 27718466 nps
Run 13: 28515207 nps
Run 14: 27776185 nps
Run 15: 28099695 nps
Run 16: 28624989 nps
Run 17: 27885181 nps
Run 18: 28434381 nps
Run 19: 28425748 nps
Run 20: 28159045 nps
-------------------------------------
Average nps over 20 runs: 28068194.3
```

## 変更後
```bash
Run  1: 30170188 nps
Run  2: 29096692 nps
Run  3: 29383185 nps
Run  4: 28427591 nps
Run  5: 29368491 nps
Run  6: 28492944 nps
Run  7: 28379802 nps
Run  8: 28394261 nps
Run  9: 29401226 nps
Run 10: 28870111 nps
Run 11: 28261435 nps
Run 12: 28893957 nps
Run 13: 29029794 nps
Run 14: 28898665 nps
Run 15: 28116279 nps
Run 16: 29309663 nps
Run 17: 29509273 nps
Run 18: 28191600 nps
Run 19: 29052729 nps
Run 20: 28280156 nps
-------------------------------------
Average nps over 20 runs: 28876402.1
```

## rank_ofもテーブルを使わない実装にした場合
```bash
Run  1: 28395492 nps
Run  2: 28000165 nps
Run  3: 29850071 nps
Run  4: 29103396 nps
Run  5: 28263798 nps
Run  6: 28778338 nps
Run  7: 28079633 nps
Run  8: 28748382 nps
Run  9: 28738726 nps
Run 10: 28532690 nps
Run 11: 28483010 nps
Run 12: 28048906 nps
Run 13: 28467038 nps
Run 14: 28114889 nps
Run 15: 28676582 nps
Run 16: 28779106 nps
Run 17: 28733463 nps
Run 18: 27992675 nps
Run 19: 28129794 nps
Run 20: 28624714 nps
-------------------------------------
Average nps over 20 runs: 28527043.4
```