### PR TITLE
方向利きのUnitTestで`all_ok &=`の代わりに`all_ok =`になっていたのを修正

### DIFF
--- a/source/bitboard.cpp
+++ b/source/bitboard.cpp
@@ -1023,11 +1023,11 @@ void Bitboard::UnitTest(Test::UnitTester& tester)
 		bool all_ok = true;
 		Bitboard occ(SQ_77);
 		Bitboard zero(ZERO);
-		all_ok = rayEffect<Effect8::DIRECT_LD>(SQ_55, occ) == between_bb(SQ_55, SQ_88);
-		all_ok = rayEffect<Effect8::DIRECT_LD>(SQ_55, zero) == QUGIY_STEP_EFFECT[Effect8::DIRECT_LD - 2][SQ_55];
+		all_ok &= rayEffect<Effect8::DIRECT_LD>(SQ_55, occ) == between_bb(SQ_55, SQ_88);
+		all_ok &= rayEffect<Effect8::DIRECT_LD>(SQ_55, zero) == QUGIY_STEP_EFFECT[Effect8::DIRECT_LD - 2][SQ_55];
 
 		Bitboard occ2(SQ_33);
-		all_ok = rayEffect<Effect8::DIRECT_RU>(SQ_55, occ2) == between_bb(SQ_55, SQ_22);
+		all_ok &= rayEffect<Effect8::DIRECT_RU>(SQ_55, occ2) == between_bb(SQ_55, SQ_22);
 
 		tester.test("rayEffect", all_ok);
 	}

--- a/source/movegen.cpp
+++ b/source/movegen.cpp
@@ -14,7 +14,7 @@ bool pseudo_legal_check(const Position& pos, ExtMove* mlist_start, ExtMove* mlis
 	bool all_ok = true;
 
 	for (auto it = mlist_start; it != mlist_end; ++it)
-		all_ok = pos.pseudo_legal_s<true>(it->move);
+		all_ok &= pos.pseudo_legal_s<true>(it->move);
 
 	// Debug用に、非合法手があった時に局面とその指し手を出力する。
 #if 0


### PR DESCRIPTION
bitboard.cppの方向利きのUnitTestにおいて
```cpp
all_ok = ...
```
と書かれていた箇所があったため、
```cpp
all_ok &= ...
```
に修正し、修正後もUnitTestが通ることを確認しました。