### PR TITLE
ThreadIdOffsetの最大値が複数NUMAノード持つCPUの時に正しく指定されていないのを修正した。

### DIFF
--- a/source/misc.h
+++ b/source/misc.h
@@ -43,6 +43,13 @@ void prefetch(const void* addr);
 // cin/coutへの入出力をファイルにリダイレクトを開始/終了する。
 void start_logger(const std::string& fname);
 
+// -----------------
+//    CPU Threads
+// -----------------
+
+// NUMAノード環境にも対応したCPUスレッド数の取得。
+int total_thread_count();
+
 // --------------------
 //  Large Page確保
 // --------------------

--- a/source/usi_option.cpp
+++ b/source/usi_option.cpp
@@ -226,7 +226,7 @@ namespace USI {
 		// (プロセッサグループは64論理コアごとに1つ作られる。上のケースでは、ThreadIdOffset = 0,0,64,64でも同じ意味。)
 		//	※　1つのPCで複数の思考エンジンを同時に起動して対局させる場合はこれを適切に設定すべき。
 
-		o["ThreadIdOffset"] << Option(0, 0, std::thread::hardware_concurrency() - 1);
+		o["ThreadIdOffset"] << Option(0, 0, total_thread_count() - 1);
 #endif
 
 #if defined(_WIN64)


### PR DESCRIPTION
`std::thread::hardware_concurrency()`が複数NUMAノード持つCPUでは期待している値を返さないので、修正しました。