### PR TITLE
AVX-512でクラッシュする問題を修正

### DIFF
--- a/source/eval/nnue/nnue_accumulator.h
+++ b/source/eval/nnue/nnue_accumulator.h
@@ -15,7 +15,8 @@ namespace NNUE {
 
 // 入力特徴量をアフィン変換した結果を保持するクラス
 // 最終的な出力である評価値も一緒に持たせておく
-struct alignas(32) Accumulator {
+// AVX-512命令を使用する場合に64bytesのアライメントが要求される。
+struct alignas(64) Accumulator {
   std::int16_t
       accumulation[2][kRefreshTriggers.size()][kTransformedFeatureDimensions];
   Value score = VALUE_ZERO;

--- a/source/eval/nnue/nnue_feature_transformer.h
+++ b/source/eval/nnue/nnue_feature_transformer.h
@@ -289,7 +289,11 @@ class FeatureTransformer {
 					const IndexType offset = kHalfDimensions * index;
 					auto accumulation      = reinterpret_cast<vec_t*>(&accumulator.accumulation[perspective][i][0]);
 					auto column            = reinterpret_cast<const vec_t*>(&weights_[offset]);
+#if defined(USE_AVX512)
+					constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
+#else
 					constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
+#endif
 					for (IndexType j = 0; j < kNumChunks; ++j) {
 						accumulation[j] = vec_add_16(accumulation[j], column[j]);
 					}
@@ -327,7 +331,11 @@ class FeatureTransformer {
 			RawFeatures::AppendChangedIndices(pos, kRefreshTriggers[i], removed_indices, added_indices, reset);
 			for (Color perspective : {BLACK, WHITE}) {
 #if defined(VECTOR)
+#if defined(USE_AVX512)
+				constexpr IndexType kNumChunks = kHalfDimensions / kSimdWidth;
+#else
 				constexpr IndexType kNumChunks = kHalfDimensions / (kSimdWidth / 2);
+#endif
 				auto accumulation              = reinterpret_cast<vec_t*>(&accumulator.accumulation[perspective][i][0]);
 #endif
 				if (reset[perspective]) {


### PR DESCRIPTION
AVX-512のコードがクラッシュする原因としては、
- Accumulatorが64bytesでアライメントされていなかった。
- kSimdWidthを2倍し忘れていた。

の2点だったようで、そこを修正することで正常に動作するようになりました。
ただ、R9-7945HXではnpsの向上は誤差でした。[このサイト](https://rigaya34589.blog.fc2.com/blog-entry-1591.html)にもある通りZEN4でのAVX-512に実装ではしょうがないのかもしれませんが。Xeonではもう少しnpsが向上するかもしれません。