### PR TITLE
`kOutputDimensions`が4で割り切れない場合の処理がなかったので追加。

### DIFF
--- a/source/eval/nnue/layers/affine_transform.h
+++ b/source/eval/nnue/layers/affine_transform.h
@@ -310,20 +310,8 @@ class AffineTransform {
 			else
 #endif
 
-			{
-				std::memcpy(output, biases_, sizeof(std::int32_t) * kOutputDimensions);
-
-				for (IndexType i = 0; i < kInputDimensions; ++i)
-				{
-					if (input[i])
-					{
-						const std::int8_t* w  = &weights_[i];
-						const int          in = input[i];
-						for (IndexType j = 0; j < kOutputDimensions; ++j)
-							output[j] += w[j * kPaddedInputDimensions] * in;
-					}
-				}
-			}
+				affine_transform_non_ssse3<kInputDimensions, kPaddedInputDimensions, kOutputDimensions>(
+				output, weights_, biases_, input);
 		}
 		else if constexpr (kOutputDimensions == 1)
 		{

--- a/source/eval/nnue/layers/affine_transform_sparse_input.h
+++ b/source/eval/nnue/layers/affine_transform_sparse_input.h
@@ -363,20 +363,8 @@ class AffineTransformSparseInput {
         }
         else
 #endif
-        {
-            std::memcpy(output, biases_, sizeof(std::int32_t) * kOutputDimensions);
-
-            for (IndexType i = 0; i < kInputDimensions; ++i)
-            {
-                if (input[i])
-                {
-                    const std::int8_t* w  = &weights_[i];
-                    const int          in = input[i];
-                    for (IndexType j = 0; j < kOutputDimensions; ++j)
-                        output[j] += w[j * kPaddedInputDimensions] * in;
-                }
-            }
-        }
+            affine_transform_non_ssse3<kInputDimensions, kPaddedInputDimensions, kOutputDimensions>(
+              output, weights_, biases_, input);
 
 #undef vec_set_32
 #undef vec_add_dpbusd_32


### PR DESCRIPTION
Stockfishから`AffineTransformSparseInput`を持ってきたときに、`kOutputDimensions`が4で割り切れない場合の処理を書いていなかったので、HalfKP 1536x2-15-32 などが正常に動作しない問題があり、それを修正しました。SIMD化していないので遅いです。