### PR TITLE
最下位ビット以外が1になる場合があるバグ修正

### DIFF
--- a/source/bitboard.h
+++ b/source/bitboard.h
@@ -1127,7 +1127,7 @@ inline Bitboard least_significant_square_bb(Bitboard b) {
 
 	u64 q0 = b.extract64<0>();
 	u64 q1 = b.extract64<1>();
-	return (q0 != 0) ? Bitboard(q0 & -q0 , q1) : Bitboard(q0, q1 & -q1);
+	return (q0 != 0) ? Bitboard(q0 & -q0 , 0) : Bitboard(0, q1 & -q1);
 }
 
 


### PR DESCRIPTION
最下位ビット以外が1になる場合があるため、修正しました。