### PR TITLE
TensorRT10系に対応

### DIFF
--- a/source/eval/deep/nn_tensorrt.cpp
+++ b/source/eval/deep/nn_tensorrt.cpp
@@ -89,33 +89,25 @@ namespace Eval::dlshogi
 		checkCudaErrors(cudaMalloc((void**)&y1_dev, sizeof(NN_Output_Policy) * max_batch_size));
 		checkCudaErrors(cudaMalloc((void**)&y2_dev, sizeof(NN_Output_Value)  * max_batch_size));
 
-		infer_inputBindings = { x1_dev, x2_dev, y1_dev, y2_dev };
-
 		return load_model(model_path);
 	}
 
 	void NNTensorRT::release()
 	{
-		// load()でメモリ確保を行った場合、inputBindings.size() == 4のはず。
-		if (infer_inputBindings.size())
-		{
-			// 安全のため、GPU IDをスレッドと関連付けてから開放する。
-			// ※　これは本来しなくても良いと思うのだが、ドライバー側の実装次第では
-			//     何か地雷を踏む可能性がなくはないので安全側に倒しておく。
+		// 安全のため、GPU IDをスレッドと関連付けてから開放する。
+		// ※　これは本来しなくても良いと思うのだが、ドライバー側の実装次第では
+		//     何か地雷を踏む可能性がなくはないので安全側に倒しておく。
 
-			// メモリを確保した時のCUDAデバイスを設定する。
-			set_device(gpu_id);
+		// メモリを確保した時のCUDAデバイスを設定する。
+		set_device(gpu_id);
 
-			// メモリの開放
-			checkCudaErrors(cudaFree(p1_dev));
-			checkCudaErrors(cudaFree(p2_dev));
-			checkCudaErrors(cudaFree(x1_dev));
-			checkCudaErrors(cudaFree(x2_dev));
-			checkCudaErrors(cudaFree(y1_dev));
-			checkCudaErrors(cudaFree(y2_dev));
-			infer_inputBindings.resize(0);
-
-		}
+		// メモリの開放
+		checkCudaErrors(cudaFree(p1_dev));
+		checkCudaErrors(cudaFree(p2_dev));
+		checkCudaErrors(cudaFree(x1_dev));
+		checkCudaErrors(cudaFree(x2_dev));
+		checkCudaErrors(cudaFree(y1_dev));
+		checkCudaErrors(cudaFree(y2_dev));
 	}
 
 	// 使用可能なデバイス数を取得する。

--- a/source/eval/deep/nn_tensorrt.h
+++ b/source/eval/deep/nn_tensorrt.h
@@ -77,9 +77,6 @@ namespace Eval::dlshogi
 		NN_Output_Policy* y1_dev;
 		NN_Output_Value * y2_dev;
 
-		// x1_dev,x2_dev,y1_dev,y2_devをひとまとめにしたもの。
-		std::vector<void*> infer_inputBindings;
-
 		// ↑で確保されたメモリを開放する。
 		void release();
 


### PR DESCRIPTION
ふかうら王をTensorRT10系で動くように書き換えました
`nvcr.io/nvidia/tensorrt:24.10-py3`上(CUDA 12.6.2、TensorRT 10.5.0.18)で動作することを確認しています。
手元にWindowsマシンがないためWindowsでの動作確認はできていないです。