### PR TITLE
探索ラムダ内の StateInfo の寿命を修正

### DIFF
--- a/source/engine/yaneuraou-engine/yaneuraou-search.cpp
+++ b/source/engine/yaneuraou-engine/yaneuraou-search.cpp
@@ -2018,7 +2018,7 @@ Value YaneuraOuWorker::search(Position& pos, Stack* ss, Value alpha, Value beta,
         evaluated = true;
         return this->evaluate(pos);
     };
-    auto do_move = [&](Position & pos, Move move, StateInfo st, bool givesCheck, Stack* ss) {
+    auto do_move = [&](Position & pos, Move move, StateInfo& st, bool givesCheck, Stack* ss) {
         if (!evaluated)
         {
             evaluated = true;
@@ -2029,7 +2029,7 @@ Value YaneuraOuWorker::search(Position& pos, Stack* ss, Value alpha, Value beta,
 
 	// 🤔 同じ名前で呼び分けできないので、
 	//     こちらを名前を do_move_ にする。
-    auto do_move_ = [&](Position & pos, Move move, StateInfo st, Stack* ss) {
+    auto do_move_ = [&](Position & pos, Move move, StateInfo& st, Stack* ss) {
         if (!evaluated)
         {
             evaluated = true;
@@ -2037,7 +2037,7 @@ Value YaneuraOuWorker::search(Position& pos, Stack* ss, Value alpha, Value beta,
         }
         this->do_move(pos, move, st, ss);
     };
-    auto do_null_move = [&](Position& pos, StateInfo st) {
+    auto do_null_move = [&](Position& pos, StateInfo& st) {
         if (!evaluated)
         {
             evaluated = true;
@@ -2046,7 +2046,7 @@ Value YaneuraOuWorker::search(Position& pos, Stack* ss, Value alpha, Value beta,
         this->do_null_move(pos, st);
     };
 #else
-    auto do_move_ = [&](Position& pos, Move move, StateInfo st, Stack* ss) { this->do_move(pos, move, st, ss); };
+    auto do_move_ = [&](Position& pos, Move move, StateInfo& st, Stack* ss) { this->do_move(pos, move, st, ss); };
 #endif
 
 	// 📌 Timerの監視
@@ -4179,7 +4179,7 @@ Value Search::YaneuraOuWorker::qsearch(Position& pos, Stack* ss, Value alpha, Va
         evaluated = true;
         return this->evaluate(pos);
     };
-    auto do_move = [&](Position& pos, Move move, StateInfo st, bool givesCheck, Stack* ss) {
+    auto do_move = [&](Position& pos, Move move, StateInfo& st, bool givesCheck, Stack* ss) {
         if (!evaluated)
         {
             evaluated = true;


### PR DESCRIPTION
## 概要
- 探索ラムダから参照する StateInfo の保存先を安定化し、寿命切れが起きないように修正します。

## 検証
- make -C source -j4 normal EVAL_EMBEDDING=OFF

## 元コミット
- 938ba0f353447ad8ef875bbd7b549ca7fcc4fe0b