### PR TITLE
skip double/triple extensions for capture moves

### DIFF
--- a/source/engine/yaneuraou-engine/yaneuraou-search.cpp
+++ b/source/engine/yaneuraou-engine/yaneuraou-search.cpp
@@ -3761,8 +3761,11 @@ moves_loop:  // When in check, search starts here
 
                 // 📝 2重延長を制限して探索の組合せ爆発を回避する必要がある。
 
-                extension =
-                  1 + (value < singularBeta - doubleMargin) + (value < singularBeta - tripleMargin);
+                if (pos.capture(move))
+                    extension = 1;
+                else
+                    extension =
+                      1 + (value < singularBeta - doubleMargin) + (value < singularBeta - tripleMargin);
 
                 depth++;
             }


### PR DESCRIPTION
tanuki-チームでWCSC36に向けて採用されたパッチの一つです。
参照: https://github.com/nodchip/tanuki-/pull/6