### PR TITLE
makebook peta_shockでdepthがleafまでの距離として再計算されない問題を修正

### DIFF
--- a/source/book/makebook2025.cpp
+++ b/source/book/makebook2025.cpp
@@ -783,17 +783,17 @@ namespace MakeBook2025
 							sync_cout << "info string Error! : invalid ybb moves area : " << readbook_path << sync_endl;
 							return Tools::ResultCode::FileReadError;
 						}
-						u16 depth = 0;
 						if (ybb_flags & YBB_FLAG_MOVE_DEPTH)
 						{
-							if (!read_u16_le(moves_reader, depth))
+							// depthフィールドは読み飛ばすが、入力値は後退解析に使用しない。
+							u16 ignored_depth;
+							if (!read_u16_le(moves_reader, ignored_depth))
 							{
 								if (!fast)
 									sfen_writer.Close();
 								sync_cout << "info string Error! : invalid ybb moves area : " << readbook_path << sync_endl;
 								return Tools::ResultCode::FileReadError;
 							}
-							depth = std::min(depth, BOOK_DEPTH_MAX);
 						}
 						Move16 move16 = Move16(move16_value);
 						auto value = (s16)std::clamp((int)(s16)eval_value, BOOK_VALUE_MIN, BOOK_VALUE_MAX);
@@ -801,7 +801,8 @@ namespace MakeBook2025
 						if (book_node.color == WHITE)
 							move16 = flip_move(move16);
 
-						book_node.moves.emplace_back(BookMove(move16, value, depth));
+						// 入力側の指し手はleaf候補なので、入力depthを引き継がず0として後退解析する。
+						book_node.moves.emplace_back(BookMove(move16, value, 0));
 					}
 				}
 
@@ -958,7 +959,6 @@ namespace MakeBook2025
 				auto move_str   = scanner.get_text();
 				auto ponder_str = scanner.get_text(); // 使わないがskipはしないといけない。
 				auto value      = (s16)std::clamp((int)scanner.get_number(0), BOOK_VALUE_MIN, BOOK_VALUE_MAX);
-				auto depth      = (u16)std::clamp((int)scanner.get_number(0), 0, int(BOOK_DEPTH_MAX));
 				Move16 move16 = (move_str == "none" || move_str == "None" || move_str == "resign") ? Move16::none() : USIEngine::to_move16(move_str);
 				//Move16 ponder = (ponder_str == "none" || ponder_str == "None" || ponder_str == "resign") ? Move16::none() : USI::to_move16(ponder_str);
 
@@ -967,7 +967,8 @@ namespace MakeBook2025
 				if (book_node.color == WHITE)
 					move16 = flip_move(move16);
 
-				book_node.moves.emplace_back(BookMove(move16, value, depth));
+				// 入力側の指し手はleaf候補なので、入力depthを引き継がず0として後退解析する。
+				book_node.moves.emplace_back(BookMove(move16, value, 0));
 				// あとで合流のチェックをしてleaf nodeであるかを確認する。
 			}
 			if (!fast)


### PR DESCRIPTION
やねうら王Wikiには、`makebook peta_shock` の `depth` について

> `makebook peta_shock` は入力定跡の `depth` を使いません。`.db` でも `.ybb` でも、入力側の leaf は `depth=0` とみなし、peta shock 化の出力時に leaf までの距離として `depth` を新しく計算します。

とあります。

しかし、[374bdd72](https://github.com/yaneurao/YaneuraOu/commit/374bdd72de45c9c33f89de62de5d76c17782499d) 以降、`.db` と `.ybb` の入力定跡から読み込んだ `depth` が leaf の初期値として使用されていました。

そのため、出力される `depth` は純粋な「leaf までの距離」ではなく、「入力側の leaf が持つ `depth` + leaf までの距離」になっていました。

本PRでは、`.db` と `.ybb` のいずれについても入力側の `depth` を使用せず、leaf の `depth` を0として後退解析するよう修正しました。
これにより、出力時に leaf までの距離として `depth` が新しく計算される本来の挙動に戻ることを確認しています。