### PR TITLE
WASM版のビルドと動作を修正。

### DIFF
--- a/.github/workflows/make-wasm.yml
+++ b/.github/workflows/make-wasm.yml
@@ -19,11 +19,11 @@ jobs:
     strategy:
       matrix:
         edition:
-          # - halfkp
+          - halfkp
           - halfkp.noeval
           - halfkpe9.noeval
           - halfkpvm.noeval
-          # - k-p
+          - k-p
           - k-p.noeval
           - material
           - material9

--- a/source/Makefile
+++ b/source/Makefile
@@ -229,7 +229,14 @@ else
 		EM_EXPORT_NAME=YaneuraOu
 		EM_INITIAL_MEMORY_SIZE=$(shell if [ $(MATERIAL_LEVEL) -ge 5 ]; then echo 385875968; else echo 138412032; fi)
 		CPPFLAGS += -Wno-unused-parameter
-		CPPFLAGS += -DUSE_WASM_SIMD -msimd128
+		# 🚧 ワークアラウンド : USE_WASM_SIMDは定義しない。
+		#     eval/nnue/wasm_simd.cppのカーネルは重みを行優先の配置で読むが、
+		#     USE_SSE42からUSE_SSSE3が有効になるため、AffineTransform::GetWeightIndex()は
+		#     重みをSSSE3向けに並べ替えて格納する。この不整合により、AffineTransformの
+		#     出力が正しくならない。
+		#     定義しなくても-msse4.2と-msimd128により、SSSE3向けの実装が
+		#     wasm simd128にコンパイルされる。
+		CPPFLAGS += -msimd128
 		CPPFLAGS += -DUSE_SSE42 -msse4.2
 		CPPFLAGS += -pthread
 		CPPFLAGS += -s STRICT=1
@@ -491,6 +498,13 @@ ifneq (,$(IS_NNUE_EDITION))
 	endif
 	ifeq ($(EVAL_EMBEDDING),ON)
 		CPPFLAGS += -DNNUE_EMBEDDING
+		ifneq (,$(findstring em++,$(COMPILER)))
+			# 📝 incbin.hによるパラメーターの埋め込みは、.incbinで置いたデータシンボルを
+			#     wasm-ldがリンクできないため使えない。代わりに、パラメーターを文字列リテラルとして
+			#     持つembedded_nnue.cppをリンクする。このファイルはscript/wasm_build.jsが生成する。
+			SOURCES += \
+				eval/nnue/embedded_nnue.cpp
+		endif
 	endif
 endif
 

--- a/source/engine/dlshogi-engine/FukauraOuEngine.cpp
+++ b/source/engine/dlshogi-engine/FukauraOuEngine.cpp
@@ -522,8 +522,14 @@ void engine_main() {
     usi->set_engine(*engine);  // エンジン実装を差し替える。
     usi->enqueue_startup_commands(CommandLine::g);
 
+#if defined(__EMSCRIPTEN__)
+    // 🌈 wasmではloop()が即座にreturnするので、インスタンスを保持したうえでJS側に制御を返す。
+    //     以後のコマンドはusi_command()経由で実行される。
+    wasm_keep_alive(std::move(engine), std::move(usi));
+#else
     // USIコマンドの応答のためのループ
     usi->loop();
+#endif
 }
 
 // このentry pointを登録しておく。

--- a/source/engine/tanuki-mate-engine/tanuki-mate-search.cpp
+++ b/source/engine/tanuki-mate-engine/tanuki-mate-search.cpp
@@ -1136,8 +1136,14 @@ namespace {
 		usi->set_engine(*engine);  // エンジン実装を差し替える。
 		usi->enqueue_startup_commands(CommandLine::g);
 
+#if defined(__EMSCRIPTEN__)
+		// 🌈 wasmではloop()が即座にreturnするので、インスタンスを保持したうえでJS側に制御を返す。
+		//     以後のコマンドはusi_command()経由で実行される。
+		wasm_keep_alive(std::move(engine), std::move(usi));
+#else
 		// USIコマンドの応答のためのループ
 		usi->loop();
+#endif
 	}
 
 	// このentry pointを登録しておく。

--- a/source/engine/user-engine/user-search.cpp
+++ b/source/engine/user-engine/user-search.cpp
@@ -148,8 +148,14 @@ namespace {
 		usi->set_engine(*engine);  // エンジン実装を差し替える。
 		usi->enqueue_startup_commands(CommandLine::g);
 
+#if defined(__EMSCRIPTEN__)
+		// 🌈 wasmではloop()が即座にreturnするので、インスタンスを保持したうえでJS側に制御を返す。
+		//     以後のコマンドはusi_command()経由で実行される。
+		wasm_keep_alive(std::move(engine), std::move(usi));
+#else
 		// USIコマンドの応答のためのループ
 		usi->loop();
+#endif
 	}
 
 	// このentry pointを登録しておく。

--- a/source/engine/yaneuraou-engine/yaneuraou-search.cpp
+++ b/source/engine/yaneuraou-engine/yaneuraou-search.cpp
@@ -5929,8 +5929,14 @@ void engine_main() {
     usi->set_engine(*engine);  // エンジン実装を差し替える。
     usi->enqueue_startup_commands(CommandLine::g);
 
+#if defined(__EMSCRIPTEN__)
+    // 🌈 wasmではloop()が即座にreturnするので、インスタンスを保持したうえでJS側に制御を返す。
+    //     以後のコマンドはusi_command()経由で実行される。
+    wasm_keep_alive(std::move(engine), std::move(usi));
+#else
     // USIコマンドの応答のためのループ
     usi->loop();
+#endif
 }
 
 // このentry pointを登録しておく。

--- a/source/engine/yaneuraou-mate-engine/yaneuraou-mate-search.cpp
+++ b/source/engine/yaneuraou-mate-engine/yaneuraou-mate-search.cpp
@@ -250,8 +250,14 @@ namespace {
 		usi->set_engine(*engine);  // エンジン実装を差し替える。
 		usi->enqueue_startup_commands(CommandLine::g);
 
+#if defined(__EMSCRIPTEN__)
+		// 🌈 wasmではloop()が即座にreturnするので、インスタンスを保持したうえでJS側に制御を返す。
+		//     以後のコマンドはusi_command()経由で実行される。
+		wasm_keep_alive(std::move(engine), std::move(usi));
+#else
 		// USIコマンドの応答のためのループ
 		usi->loop();
+#endif
 	}
 
 	// このentry pointを登録しておく。

--- a/source/eval/nnue/evaluate_nnue.cpp
+++ b/source/eval/nnue/evaluate_nnue.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
 #include <cstring>
 #include <fstream>
 #include <limits>
@@ -83,6 +84,19 @@ void add_options_(OptionsMap& options, ThreadPool& threads) {
                     return std::nullopt;
                 }));
 
+#if defined(__EMSCRIPTEN__)
+    // 📝 wasmでは評価関数ファイル名をJS側から指定できるようにする。
+    //     JS側はEmscriptenの仮想FSにファイルを書き出したあと、
+    //     "setoption name EvalFile value ..."を送ってくる。
+    // ⚠ load_eval()はwasmのとき、EvalDirが"<internal>"でもOptions["EvalFile"]を
+    //     参照するので、埋め込み版でもこのOptionは必要。
+    Options.add("EvalFile", Option(EvalFileDefaultName, [](const Option&) {
+                    // 評価関数ファイル名の変更に際して、読み込みフラグをクリアする。
+                    eval_loaded = false;
+                    return std::nullopt;
+                }));
+#endif
+
     // NNUEのFV_SCALEの値
     Options.add("FV_SCALE", Option(16, 1, 128, [&](const Option& o) {
                     YaneuraOu::Eval::NNUE::FV_SCALE = int(o);
@@ -109,7 +123,16 @@ void add_options_(OptionsMap& options, ThreadPool& threads) {
 //     const unsigned int         gEmbeddedNNUESize;    // 埋め込まれたファイルのサイズ
 // なお、この方法は Microsoft Visual Studio では動作しません。
 
-#if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
+#if defined(__EMSCRIPTEN__) && !defined(NNUE_EMBEDDING_OFF)
+// 📝 WebAssemblyではincbin.hは使えない。incbin.hはモジュールレベルのinline asmで
+//     データシンボルを置くが、wasmはデータシンボルをtextセクションに置けないため
+//     "data symbols must live in a data section"となる。-fltoではアセンブルが
+//     リンク時まで遅延されるので、コンパイルは通りwasm-ldがSIGABRTで落ちる。
+//     代わりに、パラメーターを文字列リテラルとして持つembedded_nnue.cpp
+//     (script/wasm_build.jsが生成)をリンクする。
+extern const char*       gEmbeddedNNUEData;
+extern const std::size_t gEmbeddedNNUESize;
+#elif !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
 INCBIN(EmbeddedNNUE, EvalFileDefaultName);
 #else
 const unsigned char        gEmbeddedNNUEData[1] = { 0x0 };
@@ -144,7 +167,14 @@ namespace {
 	// ⇨  StockfishはNNUEとして大きなnetworkと小さなnetworkがある。
 
 	EmbeddedNNUE get_embedded() {
+#if defined(__EMSCRIPTEN__) && !defined(NNUE_EMBEDDING_OFF)
+		// embedded_nnue.cppは先頭ポインタとサイズしか提供しないので、終端はここで計算する。
+		const auto* data = reinterpret_cast<const unsigned char*>(gEmbeddedNNUEData);
+		return EmbeddedNNUE(data, data + gEmbeddedNNUESize,
+			static_cast<unsigned int>(gEmbeddedNNUESize));
+#else
 		return EmbeddedNNUE(gEmbeddedNNUEData, gEmbeddedNNUEEnd, gEmbeddedNNUESize);
+#endif
 	}
 }
 
@@ -870,7 +900,14 @@ void load_eval() {
     #endif
         const Tools::Result result = [&] {
             if (dir_name != "<internal>") {
+            #if !defined(__EMSCRIPTEN__)
                 auto abs_eval_path = Path::Combine(Directory::GetBinaryFolder(), dir_name);
+            #else
+                // 📝 wasmでは評価関数ファイルはEmscriptenの仮想FS上にある。
+                //     Directory::GetBinaryFolder()はホスト側のパスを返すので前置せず、
+                //     EvalDirをそのまま仮想FS上のパスとして扱う。
+                auto abs_eval_path = dir_name;
+            #endif
                 const std::string file_path = Path::Combine(abs_eval_path, file_name);
                 std::ifstream stream(file_path, std::ios::binary);
                 sync_cout << "info string loading eval file : " << file_path << sync_endl;

--- a/source/thread.cpp
+++ b/source/thread.cpp
@@ -62,16 +62,21 @@ Thread::Thread(Search::SharedState& sharedState,
 
 #else
     // yaneuraou.wasm
-    // wait_for_search_finished すると、ブラウザのメインスレッドをブロックしデッドロックが発生するため、コメントアウト。
+    // wait_for_search_finished すると、ブラウザのメインスレッドをブロックしデッドロックが発生するため、待機しない。
     //
     // 新しいスレッドが cv を設定するのを待ってから、ブラウザに処理をパスしたいが、
     // 新しいスレッド用のworkerを作成するためには、いったんブラウザに処理をパスする必要がある。
     //
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1049079
     //
-    // threadStarted という変数を設けて全てのスレッドが開始するまでリトライするようにする
-    //
-    // 参考：https://github.com/lichess-org/stockfish.wasm/blob/a022fa1405458d1bc1ba22fe813bace961859102/src/thread.cpp#L38
+    // 📝 同じ理由でrun_custom_job()の完了も待てないため、workerは生成スレッド上で直接生成する。
+    //     run_custom_job()に任せると、ジョブが実行される前にThread::clear_worker()が
+    //     worker == nullptrのまま呼ばれうる。
+    //     run_custom_job()を経由する目的はNUMAノードにbindしたスレッド上で
+    //     workerのメモリを確保することだが、wasmにNUMAは無い。
+    this->numaAccessToken = binder();
+    this->worker          = std::move(
+      worker_factory(sharedState, {n, idxInNuma, totalNuma, this->numaAccessToken}));
 #endif
 }
 

--- a/source/usi.cpp
+++ b/source/usi.cpp
@@ -120,6 +120,12 @@ void USIEngine::set_engine(IEngine& _engine) {
             print_info_string(*str);
     });
 
+#if defined(ENGINE_OPTIONS)
+    // 🌈 ENGINE_OPTIONSマクロで指定されたエンジンオプションを反映させる。
+    //     上書き対象のオプションがすべて生えたあとに行う必要があるので、ここで呼び出す。
+    engine.get_options().set_engine_options(ENGINE_OPTIONS);
+#endif
+
     // 📝 セットされたEngineに対してlisterを設定する必要がある。
     //     Stockfishは、USIEngineのコンストラクタで行っているが、
     //     やねうら王ではEngineの差し替えができるのでこのタイミング。
@@ -1800,30 +1806,45 @@ std::string USIEngine::value(Value v)
 
 
 
+#endif
+
 #if defined(__EMSCRIPTEN__)
 // --------------------
 // EMSCRIPTEN support
 // --------------------
-static StateListPtr states(new StateList(1));
+
+namespace {
+// wasm_keep_alive()で保持するインスタンス。プロセス終了まで解放しない。(理由はusi.hを参照)
+std::unique_ptr<IEngine>   wasm_engine;
+std::unique_ptr<USIEngine> wasm_usi;
+}  // namespace
+
+void wasm_keep_alive(std::unique_ptr<IEngine> engine, std::unique_ptr<USIEngine> usi) {
+    wasm_engine = std::move(engine);
+    wasm_usi    = std::move(usi);
+}
+
+USIEngine* wasm_usi_instance() { return wasm_usi.get(); }
+
+int USIEngine::exec_command_from_js(const std::string& cmd) {
+    // 💡 usi_cmdexec()の戻り値("quit"ならtrue)は使わない。
+    //     "quit"はwasm_pre.jsが先にModule.terminate()で処理するため、ここには届かない。
+    usi_cmdexec(cmd);
+
+    return 0;
+}
 
 // USI応答部 emscriptenインターフェース
-EMSCRIPTEN_KEEPALIVE extern "C" int usi_command(const char *c_cmd) {
-	std::string cmd(c_cmd);
+// 💡 wasm_pre.jsからModule.ccall("usi_command", ...)で呼び出される。
+EMSCRIPTEN_KEEPALIVE extern "C" int usi_command(const char* c_cmd) {
+    USIEngine* usi = wasm_usi_instance();
 
-	static Position pos;
-	string token;
+    // engine_main()が未実行。JS側に再送してもらう。
+    if (usi == nullptr)
+        return 1;
 
-	for (Thread* th : Threads) {
-		if (!th->threadStarted)
-			return 1;
-	}
-
-	usi_cmdexec(pos, states, cmd);
-
-	return 0;
+    return usi->exec_command_from_js(std::string(c_cmd));
 }
-#endif
-
 #endif
 
 } // namespace YaneuraOu

--- a/source/usi.h
+++ b/source/usi.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <iosfwd>
 #include <map>
+#include <memory>
 #include <string>
 
 #include "types.h"
@@ -37,7 +38,17 @@ public:
 
 	// main threadをUSIメッセージの受信のために待機させる。
 	// "quit"コマンドが送られてくるまでこのループは抜けない。
+	// 📝 wasmではブラウザのメインスレッドをブロックできないため、この関数は何もしない。
+	//     代わりにwasm_pre.jsからusi_command()経由でexec_command_from_js()が呼び出される。
 	void loop();
+
+#if defined(__EMSCRIPTEN__)
+	// yaneuraou.wasm : JS側から渡されたUSIコマンドを1つ実行する。
+	// 戻り値はそのままwasm_pre.jsに返る。
+	//   0 : 受理した。
+	//   1 : まだ実行できない。あとで再送してもらう。
+	int exec_command_from_js(const std::string& cmd);
+#endif
 
 	// --------------------
 	// USI関係の記法変換部
@@ -240,6 +251,26 @@ private:
 
 #endif
 };
+
+#if defined(__EMSCRIPTEN__)
+// --------------------
+// 🌈 yaneuraou.wasm 用のヘルパー 🌈
+// --------------------
+
+/*
+	📝 wasmではUSIEngine::loop()が即座にreturnするので、各エンジンのentry pointである
+	    engine_main()もすぐに抜ける。engine_main()はEngineとUSIEngineを
+	    std::unique_ptrのlocal変数として持っているため、そのまま抜けると両者が解体され、
+	    以後JS側からusi_command()を呼んでも実体が無い。
+	    (解体時にThread::~Thread()がjoinするため、メインスレッドが停止する危険もある。)
+
+	    そこでengine_main()の末尾でこの関数にmoveし、プロセス終了までインスタンスを保持する。
+*/
+void wasm_keep_alive(std::unique_ptr<IEngine> engine, std::unique_ptr<USIEngine> usi);
+
+// wasm_keep_alive()で保持しているUSIEngineを返す。未登録ならnullptr。
+USIEngine* wasm_usi_instance();
+#endif
 
 } // namespace YaneuraOu
 

--- a/source/usioption.cpp
+++ b/source/usioption.cpp
@@ -366,18 +366,19 @@ std::ostream& operator<<(std::ostream& os, const OptionsMap& om) {
 	// 評価関数を読み込んだかのフラグ。これはevaldirの変更にともなってfalseにする。
 	bool load_eval_finished = false;
 
-	// エンジンオプションをコンパイル時に設定する機能
-	// "ENGINE_OPTIONS"で指定した内容を設定する。
-	// 例) #define ENGINE_OPTIONS "FV_SCALE=24;BookFile=no_book"
-	void set_engine_options(const std::string& options)
-	{
-		// ";"で区切って複数指定できるものとする。
-		auto v = StringExtension::Split(options, ";");
-		for (auto line : v)
-			build_option(std::string(line));
-	}
-
 #endif
+
+// エンジンオプションをコンパイル時に設定する機能
+// "ENGINE_OPTIONS"で指定した内容を設定する。
+// 例) #define ENGINE_OPTIONS "FV_SCALE=24;BookFile=no_book"
+// 📝 USIEngine::set_engine()から、すべてのオプションが生えたあとに呼び出される。
+void OptionsMap::set_engine_options(const std::string& options)
+{
+	// ";"で区切って複数指定できるものとする。
+	auto v = StringExtension::Split(options, ";");
+	for (auto line : v)
+		build_option(std::string(line));
+}
 
 // --------------------
 //  やねうら王独自拡張

--- a/source/usioption.h
+++ b/source/usioption.h
@@ -161,6 +161,13 @@ class OptionsMap {
     // 通常の"setoption"では変更できない。
     void read_engine_options(const std::string& filename);
 
+    // ENGINE_OPTIONSマクロで、コンパイル時にエンジンオプションを設定する機能。
+    // ";"区切りで複数指定できる。
+    // 例) #define ENGINE_OPTIONS "FV_SCALE=24;BookFile=no_book"
+    // ⚠ read_engine_options()と同様、ここで設定した値はfixedフラグが立ち、
+    //     そのあと通常の"setoption"では変更できない。
+    void set_engine_options(const std::string& options);
+
     // option名を指定して、その値を出力した文字列を構成する。
     // option名が省略された時は、すべてのオプションの値を出力した文字列を構成する。
     std::string get_option(const std::string& option_name);


### PR DESCRIPTION
@yaneurao 
お世話になっております。
WASM 版のビルドがそのままでは利用できない状態のようでしたので、その修正を試みました。
よろしければ、お時間の都合の良いときにご確認いただけますでしょうか。

## 概要

[wasm_build.sh](https://github.com/yaneurao/YaneuraOu/blob/master/script/wasm_build.sh) を実行すると Docker コンテナ上で WASM 版のビルドが走りますが、昨年の大規模改修を主な要因として利用できない状態であるように見受けられます。

そこで、 WASM 版のビルド設定と関連する実装の修正を行いました。

## 修正内容

単にビルドがコケるだけではなく、ビルドが通るようになっても USI コマンドを受け付けなかったり、異常な評価値が出る問題がありました。
そのため、いくつかのソースファイルに `defined(__EMSCRIPTEN__)` で WASM 専用コードを書く必要がありました。

作業は Claude Code Opus 5 (一部 Fable 5) を使用しています。
できるだけ自分でも内容を理解するように努めましたが、特に評価関数周りの修正は深く理解できていません。
ただ、内容を見返した上で WASM 以外への影響はない形になっていると考えています。

以下は AI に書かせた要約を少し私が直したものです。

### ビルド

- EVAL_EMBEDDING=ON の場合に wasm-ld が通らないため embedded_nnue.cpp をリンクするように修正
- CI でコメントアウトされていた halfkp と k-p が利用可能になったので復帰

### USI コマンドの受け付け

- 大規模改修でオブジェクトのライフサイクルが変わり（大規模改修の前は状態がグローバル変数が使われていた）、そのままでは利用できないため  wasm_keep_alive() を作成
- #if 0 で無効になっていた usi_command() を、現在の API に合わせて書き直し復活
- WASM では Worker が生成されず isready で落ちていたのを修正

### 評価関数

- EvalFile オプションを WASM 限定で復活。登録側が失われ、未登録キーで Tools::exit() していた
- パス解決から Directory::GetBinaryFolder() の前置を除去。仮想 FS 上のファイルが見つからなかった
- USE_WASM_SIMD を無効化。重みの配置が不整合で評価値が正しく計算されず、探索が極端に弱くなっていた
- #if 0 に巻き込まれていた ENGINE_OPTIONS の適用を復活。FV_SCALE が効いていなかった

## 動作確認

生成された halfkp（水匠5埋め込み）と halfkp.noeval を ShogiHome に組み込んで、それぞれ動作することを確認しました。

また、通常版への影響がないことを見るために、macOS 版をビルドして検討や対局ができることを確認しました。